### PR TITLE
Updated locality names in LT

### DIFF
--- a/data/125/971/958/9/1259719589.geojson
+++ b/data/125/971/958/9/1259719589.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Micaiciai"
+    ],
+    "name:eng_x_variant":[
+        "Mircaiciai"
+    ],
     "name:lit_x_preferred":[
         "Mircai\u010diai"
     ],
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":1259719589,
-    "wof:lastmodified":1566598320,
-    "wof:name":"Mircaiciai",
+    "wof:lastmodified":1574296091,
+    "wof:name":"Micaiciai",
     "wof:parent_id":102073699,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-lt",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743.

Updates name translations and `wof:name` values for Micaiciai, Lithuania,

No PIP work required, can merge once required.