### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/752/741/101752741.geojson
+++ b/data/101/752/741/101752741.geojson
@@ -264,6 +264,9 @@
         "wk:page":"Alytus"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56d4e9cd114eac626c02ee85f397480b",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":101752741,
-    "wof:lastmodified":1566597915,
+    "wof:lastmodified":1582348265,
     "wof:name":"Alytus",
     "wof:parent_id":102073587,
     "wof:placetype":"locality",

--- a/data/101/752/743/101752743.geojson
+++ b/data/101/752/743/101752743.geojson
@@ -245,6 +245,9 @@
         "wk:page":"Marijampol\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc16f6a03e513ab17849015eef7b8702",
     "wof:hierarchy":[
         {
@@ -256,7 +259,7 @@
         }
     ],
     "wof:id":101752743,
-    "wof:lastmodified":1566597915,
+    "wof:lastmodified":1582348265,
     "wof:name":"Marijampol\u0117",
     "wof:parent_id":102073595,
     "wof:placetype":"locality",

--- a/data/101/752/745/101752745.geojson
+++ b/data/101/752/745/101752745.geojson
@@ -498,6 +498,9 @@
         "qs_pg:id":1059310
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8fa8f18e02e533ffec8abb06c7d650c8",
     "wof:hierarchy":[
         {
@@ -509,7 +512,7 @@
         }
     ],
     "wof:id":101752745,
-    "wof:lastmodified":1566597915,
+    "wof:lastmodified":1582348265,
     "wof:name":"Kaunas",
     "wof:parent_id":102073611,
     "wof:placetype":"locality",

--- a/data/101/752/747/101752747.geojson
+++ b/data/101/752/747/101752747.geojson
@@ -548,6 +548,9 @@
         "wd:id":"Q776965"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa94d22b740f4a23f6a989d11fb20c3b",
     "wof:hierarchy":[
         {
@@ -559,7 +562,7 @@
         }
     ],
     "wof:id":101752747,
-    "wof:lastmodified":1566597915,
+    "wof:lastmodified":1582348265,
     "wof:name":"Klaip\u0117da",
     "wof:parent_id":102073657,
     "wof:placetype":"locality",

--- a/data/101/752/751/101752751.geojson
+++ b/data/101/752/751/101752751.geojson
@@ -415,6 +415,9 @@
         "wk:page":"Panev\u0117\u017eys"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbfcc51a0c2b5c88fc48c44cbc57bcb9",
     "wof:hierarchy":[
         {
@@ -426,7 +429,7 @@
         }
     ],
     "wof:id":101752751,
-    "wof:lastmodified":1566597915,
+    "wof:lastmodified":1582348265,
     "wof:name":"Panev\u0117\u017eys",
     "wof:parent_id":102073677,
     "wof:placetype":"locality",

--- a/data/101/752/753/101752753.geojson
+++ b/data/101/752/753/101752753.geojson
@@ -436,6 +436,9 @@
         "wk:page":"\u0160iauliai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91a61a8c7707767ee011a9a51766304c",
     "wof:hierarchy":[
         {
@@ -447,7 +450,7 @@
         }
     ],
     "wof:id":101752753,
-    "wof:lastmodified":1566597915,
+    "wof:lastmodified":1582348265,
     "wof:name":"\u0160iauliai",
     "wof:parent_id":102073683,
     "wof:placetype":"locality",

--- a/data/101/753/031/101753031.geojson
+++ b/data/101/753/031/101753031.geojson
@@ -745,6 +745,9 @@
         "wk:page":"Vilnius"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec1cddc1d5b4c4b352f94ae37f4b74c5",
     "wof:hierarchy":[
         {
@@ -755,7 +758,7 @@
         }
     ],
     "wof:id":101753031,
-    "wof:lastmodified":1566597916,
+    "wof:lastmodified":1582348265,
     "wof:megacity":0,
     "wof:name":"Vilnius",
     "wof:parent_id":102073615,

--- a/data/101/817/183/101817183.geojson
+++ b/data/101/817/183/101817183.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Raseiniai District Municipality"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ca41378d134527078c3ceae0eaf6f28",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":101817183,
-    "wof:lastmodified":1566597937,
+    "wof:lastmodified":1582348268,
     "wof:name":"Raseiniai",
     "wof:parent_id":102073651,
     "wof:placetype":"locality",

--- a/data/101/817/185/101817185.geojson
+++ b/data/101/817/185/101817185.geojson
@@ -159,6 +159,9 @@
         "wd:id":"Q391582"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f36a814d05a979ca167d0f1a784b29e7",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101817185,
-    "wof:lastmodified":1566597938,
+    "wof:lastmodified":1582348268,
     "wof:name":"\u0160ilal\u0117",
     "wof:parent_id":102073655,
     "wof:placetype":"locality",

--- a/data/101/817/187/101817187.geojson
+++ b/data/101/817/187/101817187.geojson
@@ -240,6 +240,9 @@
         "wk:page":"K\u0117dainiai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a262dc7b484d26e2ffa52a1d583e96a2",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         }
     ],
     "wof:id":101817187,
-    "wof:lastmodified":1566597930,
+    "wof:lastmodified":1582348267,
     "wof:name":"K\u0117dainiai",
     "wof:parent_id":102073659,
     "wof:placetype":"locality",

--- a/data/101/817/193/101817193.geojson
+++ b/data/101/817/193/101817193.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Priekul\u0117, Lithuania"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aedf7aff8edb70197a47dbfbf3715c1d",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101817193,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Priekul\u0117",
     "wof:parent_id":102073667,
     "wof:placetype":"locality",

--- a/data/101/817/195/101817195.geojson
+++ b/data/101/817/195/101817195.geojson
@@ -171,6 +171,9 @@
         "wd:id":"Q259272"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbcaf9f28ba3b933e0319508531df09b",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":101817195,
-    "wof:lastmodified":1566597927,
+    "wof:lastmodified":1582348267,
     "wof:name":"Garg\u017edai",
     "wof:parent_id":102073667,
     "wof:placetype":"locality",

--- a/data/101/817/197/101817197.geojson
+++ b/data/101/817/197/101817197.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Rietavas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ab10f91e20f871b2a7d5e8082c53525",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101817197,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Rietavas",
     "wof:parent_id":102073669,
     "wof:placetype":"locality",

--- a/data/101/817/199/101817199.geojson
+++ b/data/101/817/199/101817199.geojson
@@ -191,6 +191,9 @@
         "wk:page":"Kelm\u0117 District Municipality"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73171dad08c91444545ada49d08a68a9",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":101817199,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Kelm\u0117",
     "wof:parent_id":102073673,
     "wof:placetype":"locality",

--- a/data/101/817/201/101817201.geojson
+++ b/data/101/817/201/101817201.geojson
@@ -129,6 +129,9 @@
         "wk:page":"U\u017eventis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5309b63e939cf21c5a59cc7b831ae24",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101817201,
-    "wof:lastmodified":1566597935,
+    "wof:lastmodified":1582348268,
     "wof:name":"U\u017eventis",
     "wof:parent_id":102073673,
     "wof:placetype":"locality",

--- a/data/101/817/203/101817203.geojson
+++ b/data/101/817/203/101817203.geojson
@@ -114,6 +114,9 @@
         "wk:page":"\u0160ventoji, Lithuania"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1dd982c1979679468f361baa98dd9638",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101817203,
-    "wof:lastmodified":1566597930,
+    "wof:lastmodified":1582348267,
     "wof:name":"\u0160ventoji",
     "wof:parent_id":102073675,
     "wof:placetype":"locality",

--- a/data/101/817/205/101817205.geojson
+++ b/data/101/817/205/101817205.geojson
@@ -231,6 +231,9 @@
         "wk:page":"Palanga"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"259a019f750b974b5c6a6228d9d2455b",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":101817205,
-    "wof:lastmodified":1566597930,
+    "wof:lastmodified":1582348267,
     "wof:name":"Palanga",
     "wof:parent_id":102073675,
     "wof:placetype":"locality",

--- a/data/101/817/211/101817211.geojson
+++ b/data/101/817/211/101817211.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Salantai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf172da0fc91d03718ef998cabc1e62d",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101817211,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Salantai",
     "wof:parent_id":102073681,
     "wof:placetype":"locality",

--- a/data/101/817/213/101817213.geojson
+++ b/data/101/817/213/101817213.geojson
@@ -178,6 +178,9 @@
         "wd:id":"Q1788115"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74fe58674867fbfd087d2543eb86aafe",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":101817213,
-    "wof:lastmodified":1566597935,
+    "wof:lastmodified":1582348268,
     "wof:name":"Kretinga",
     "wof:parent_id":102073681,
     "wof:placetype":"locality",

--- a/data/101/817/215/101817215.geojson
+++ b/data/101/817/215/101817215.geojson
@@ -151,6 +151,9 @@
         "qs_pg:id":267874
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d79044dba6f8e13db8c12a23e1a50854",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101817215,
-    "wof:lastmodified":1566597934,
+    "wof:lastmodified":1582348268,
     "wof:name":"Ignalina",
     "wof:parent_id":102073685,
     "wof:placetype":"locality",

--- a/data/101/817/217/101817217.geojson
+++ b/data/101/817/217/101817217.geojson
@@ -138,6 +138,9 @@
         "wk:page":"D\u016bk\u0161tas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a89b0c95057e1da53727c6e42b77a70",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101817217,
-    "wof:lastmodified":1566597929,
+    "wof:lastmodified":1582348267,
     "wof:name":"D\u016bk\u0161tas",
     "wof:parent_id":102073685,
     "wof:placetype":"locality",

--- a/data/101/817/219/101817219.geojson
+++ b/data/101/817/219/101817219.geojson
@@ -206,6 +206,9 @@
         "wd:id":"Q203892"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2da887d6a0767a35bf7918ee09bb80d",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":101817219,
-    "wof:lastmodified":1566597929,
+    "wof:lastmodified":1582348267,
     "wof:name":"Visaginas",
     "wof:parent_id":102073691,
     "wof:placetype":"locality",

--- a/data/101/817/223/101817223.geojson
+++ b/data/101/817/223/101817223.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Plateliai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed67c433355aebe528f55a861ef30f8b",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101817223,
-    "wof:lastmodified":1566597934,
+    "wof:lastmodified":1582348268,
     "wof:name":"Plateliai",
     "wof:parent_id":102073695,
     "wof:placetype":"locality",

--- a/data/101/817/229/101817229.geojson
+++ b/data/101/817/229/101817229.geojson
@@ -76,6 +76,9 @@
         "wk:page":"Me\u0161kui\u010diai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48f7ef7d95d1a3d316119b3ffd7fe4bf",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":101817229,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Me\u0161kui\u010diai",
     "wof:parent_id":102073703,
     "wof:placetype":"locality",

--- a/data/101/817/237/101817237.geojson
+++ b/data/101/817/237/101817237.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Mos\u0117dis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"33a1464038dd3d93259da8cc7b4ec10a",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101817237,
-    "wof:lastmodified":1566597935,
+    "wof:lastmodified":1582348268,
     "wof:name":"Mos\u0117dis",
     "wof:parent_id":102073711,
     "wof:placetype":"locality",

--- a/data/101/817/241/101817241.geojson
+++ b/data/101/817/241/101817241.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Viek\u0161niai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59394c2f18fc3a646cee693caf559302",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101817241,
-    "wof:lastmodified":1566597934,
+    "wof:lastmodified":1582348268,
     "wof:name":"Viek\u0161niai",
     "wof:parent_id":102073713,
     "wof:placetype":"locality",

--- a/data/101/817/245/101817245.geojson
+++ b/data/101/817/245/101817245.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Naujoji Akmen\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b68a462a577aa12bbb682cffd46db80a",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":101817245,
-    "wof:lastmodified":1566597929,
+    "wof:lastmodified":1582348267,
     "wof:name":"Naujoji Akmen\u0117",
     "wof:parent_id":102073715,
     "wof:placetype":"locality",

--- a/data/101/817/247/101817247.geojson
+++ b/data/101/817/247/101817247.geojson
@@ -266,6 +266,9 @@
         "wd:id":"Q1023044"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa264c1cb9f6c67d9d4ab3f064f69fbd",
     "wof:hierarchy":[
         {
@@ -277,7 +280,7 @@
         }
     ],
     "wof:id":101817247,
-    "wof:lastmodified":1566597935,
+    "wof:lastmodified":1582348268,
     "wof:name":"Akmen\u0117",
     "wof:parent_id":102073715,
     "wof:placetype":"locality",

--- a/data/101/817/251/101817251.geojson
+++ b/data/101/817/251/101817251.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Linkuva"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aeb1a68794ff4ea8b54e45c44266e256",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":101817251,
-    "wof:lastmodified":1566597930,
+    "wof:lastmodified":1582348267,
     "wof:name":"Linkuva",
     "wof:parent_id":102073717,
     "wof:placetype":"locality",

--- a/data/101/817/257/101817257.geojson
+++ b/data/101/817/257/101817257.geojson
@@ -162,6 +162,9 @@
         "wk:page":"\u017dagar\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2d39cb23b9189cbe90c3f5ac580931b",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101817257,
-    "wof:lastmodified":1566597929,
+    "wof:lastmodified":1582348267,
     "wof:name":"\u017dagar\u0117",
     "wof:parent_id":102073723,
     "wof:placetype":"locality",

--- a/data/101/817/903/101817903.geojson
+++ b/data/101/817/903/101817903.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q923643"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1812396a3a86d13fef22c9527969535b",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101817903,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Lazdijai",
     "wof:parent_id":102073583,
     "wof:placetype":"locality",

--- a/data/101/817/905/101817905.geojson
+++ b/data/101/817/905/101817905.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Veisiejai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fafd448385598511db378e38ef7e0c14",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101817905,
-    "wof:lastmodified":1566597934,
+    "wof:lastmodified":1582348268,
     "wof:name":"Veisiejai",
     "wof:parent_id":102073583,
     "wof:placetype":"locality",

--- a/data/101/817/907/101817907.geojson
+++ b/data/101/817/907/101817907.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Kalvarija, Lithuania"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6da462dd4bf5ac203b2cfe58ce49cf7d",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101817907,
-    "wof:lastmodified":1566597927,
+    "wof:lastmodified":1582348267,
     "wof:name":"Kalvarija",
     "wof:parent_id":102073585,
     "wof:placetype":"locality",

--- a/data/101/817/913/101817913.geojson
+++ b/data/101/817/913/101817913.geojson
@@ -178,6 +178,9 @@
         "wd:id":"Q835843"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c14f791f732004fed2a66e8c4e14e374",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":101817913,
-    "wof:lastmodified":1566597932,
+    "wof:lastmodified":1582348268,
     "wof:name":"Var\u0117na",
     "wof:parent_id":102073589,
     "wof:placetype":"locality",

--- a/data/101/817/915/101817915.geojson
+++ b/data/101/817/915/101817915.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Merkin\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d95b2dc62d17dbf346b8dd2a056460c7",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101817915,
-    "wof:lastmodified":1566597931,
+    "wof:lastmodified":1582348267,
     "wof:name":"Merkin\u0117",
     "wof:parent_id":102073589,
     "wof:placetype":"locality",

--- a/data/101/817/917/101817917.geojson
+++ b/data/101/817/917/101817917.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Simnas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7f9a166d754f9d735e12ffa08553acf",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101817917,
-    "wof:lastmodified":1566597937,
+    "wof:lastmodified":1582348268,
     "wof:name":"Simnas",
     "wof:parent_id":102073591,
     "wof:placetype":"locality",

--- a/data/101/817/921/101817921.geojson
+++ b/data/101/817/921/101817921.geojson
@@ -134,6 +134,9 @@
         "wd:id":"Q2044578"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13b320d8b0e43b31808f818a868c8e57",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":101817921,
-    "wof:lastmodified":1566597937,
+    "wof:lastmodified":1582348268,
     "wof:name":"Daugai",
     "wof:parent_id":102073591,
     "wof:placetype":"locality",

--- a/data/101/817/923/101817923.geojson
+++ b/data/101/817/923/101817923.geojson
@@ -167,6 +167,9 @@
         "wd:id":"Q185555"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1d840cdc0fb3715ce8c87298ab31bd6",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":101817923,
-    "wof:lastmodified":1566597931,
+    "wof:lastmodified":1582348267,
     "wof:name":"Bir\u0161tonas",
     "wof:parent_id":102073593,
     "wof:placetype":"locality",

--- a/data/101/817/925/101817925.geojson
+++ b/data/101/817/925/101817925.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Igliauka"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"12b2865374d062555c61a78ad11e7807",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101817925,
-    "wof:lastmodified":1566597932,
+    "wof:lastmodified":1582348268,
     "wof:name":"Igliauka",
     "wof:parent_id":102073595,
     "wof:placetype":"locality",

--- a/data/101/817/931/101817931.geojson
+++ b/data/101/817/931/101817931.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Ei\u0161i\u0161k\u0117s"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b9ec63f66de89b1b755196b3052ac8e9",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":101817931,
-    "wof:lastmodified":1566597927,
+    "wof:lastmodified":1582348267,
     "wof:name":"Ei\u0161i\u0161k\u0117s",
     "wof:parent_id":102073597,
     "wof:placetype":"locality",

--- a/data/101/817/935/101817935.geojson
+++ b/data/101/817/935/101817935.geojson
@@ -139,6 +139,9 @@
         "qs_pg:id":550234
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19a393c6aa9c5687142f52a2edb22b78",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101817935,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Baltoji Vok\u0117",
     "wof:parent_id":102073597,
     "wof:placetype":"locality",

--- a/data/101/817/937/101817937.geojson
+++ b/data/101/817/937/101817937.geojson
@@ -166,6 +166,9 @@
         "wd:id":"Q852272"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f30ce218b25c4f243315ff1ea99f940",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":101817937,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Vilkavi\u0161kis",
     "wof:parent_id":102073601,
     "wof:placetype":"locality",

--- a/data/101/817/939/101817939.geojson
+++ b/data/101/817/939/101817939.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Kybartai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d8931b1f4f68e6c1bda6a5b4da30067",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101817939,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Kybartai",
     "wof:parent_id":102073601,
     "wof:placetype":"locality",

--- a/data/101/817/941/101817941.geojson
+++ b/data/101/817/941/101817941.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Pilvi\u0161kiai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be06eb4ac811e57bac06a2583bef23dd",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101817941,
-    "wof:lastmodified":1566597931,
+    "wof:lastmodified":1582348267,
     "wof:name":"Pilvi\u0161kiai",
     "wof:parent_id":102073601,
     "wof:placetype":"locality",

--- a/data/101/817/943/101817943.geojson
+++ b/data/101/817/943/101817943.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Virbalis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed0c44d665ef146d940e7993d2539848",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101817943,
-    "wof:lastmodified":1566597938,
+    "wof:lastmodified":1582348268,
     "wof:name":"Virbalis",
     "wof:parent_id":102073601,
     "wof:placetype":"locality",

--- a/data/101/817/947/101817947.geojson
+++ b/data/101/817/947/101817947.geojson
@@ -179,6 +179,9 @@
         "wd:id":"Q499318"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7951b4ec96fee58e5c5307655ec741e",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":101817947,
-    "wof:lastmodified":1566597931,
+    "wof:lastmodified":1582348268,
     "wof:name":"Prienai",
     "wof:parent_id":102073603,
     "wof:placetype":"locality",

--- a/data/101/817/951/101817951.geojson
+++ b/data/101/817/951/101817951.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Jieznas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90d212b3905f398b96383a011b234f84",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101817951,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Jieznas",
     "wof:parent_id":102073603,
     "wof:placetype":"locality",

--- a/data/101/817/953/101817953.geojson
+++ b/data/101/817/953/101817953.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Balbieri\u0161kis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7efbc8bdb5ae9d70a2f634cc09823aab",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101817953,
-    "wof:lastmodified":1566597927,
+    "wof:lastmodified":1582348267,
     "wof:name":"Balbieri\u0161kis",
     "wof:parent_id":102073603,
     "wof:placetype":"locality",

--- a/data/101/817/955/101817955.geojson
+++ b/data/101/817/955/101817955.geojson
@@ -237,6 +237,9 @@
         "wk:page":"Trakai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"08db48092e75b229499af7d3d11ec324",
     "wof:hierarchy":[
         {
@@ -248,7 +251,7 @@
         }
     ],
     "wof:id":101817955,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Trakai",
     "wof:parent_id":102073605,
     "wof:placetype":"locality",

--- a/data/101/817/957/101817957.geojson
+++ b/data/101/817/957/101817957.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Lentvaris"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b99094edee29552ccaf223d0eec53c0",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101817957,
-    "wof:lastmodified":1566597932,
+    "wof:lastmodified":1582348268,
     "wof:name":"Lentvaris",
     "wof:parent_id":102073605,
     "wof:placetype":"locality",

--- a/data/101/817/959/101817959.geojson
+++ b/data/101/817/959/101817959.geojson
@@ -130,6 +130,9 @@
         "wk:page":"R\u016bdi\u0161k\u0117s"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"657caf0022d6c6441da61cc227a6d480",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101817959,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"R\u016bdi\u0161k\u0117s",
     "wof:parent_id":102073605,
     "wof:placetype":"locality",

--- a/data/101/817/961/101817961.geojson
+++ b/data/101/817/961/101817961.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Auk\u0161tadvaris"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70e3a6bdd6ad49304805647195baf871",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101817961,
-    "wof:lastmodified":1566597932,
+    "wof:lastmodified":1582348268,
     "wof:name":"Auk\u0161tadvaris",
     "wof:parent_id":102073605,
     "wof:placetype":"locality",

--- a/data/101/817/965/101817965.geojson
+++ b/data/101/817/965/101817965.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Kazl\u0173 R\u016bda"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64d6c7e511f5b25fd2e6fa4024a40a25",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101817965,
-    "wof:lastmodified":1566597927,
+    "wof:lastmodified":1582348267,
     "wof:name":"Kazl\u0173 R\u016bda",
     "wof:parent_id":102073607,
     "wof:placetype":"locality",

--- a/data/101/817/967/101817967.geojson
+++ b/data/101/817/967/101817967.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Elektr\u0117nai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16fed0fbe129126d50f88668685bb524",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101817967,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Elektr\u0117nai",
     "wof:parent_id":102073613,
     "wof:placetype":"locality",

--- a/data/101/817/969/101817969.geojson
+++ b/data/101/817/969/101817969.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Vievis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"237d768c9b30b24e9872892e9e52a0eb",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101817969,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Vievis",
     "wof:parent_id":102073613,
     "wof:placetype":"locality",

--- a/data/101/817/975/101817975.geojson
+++ b/data/101/817/975/101817975.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Vilkija"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49b2749a83384907ff479933698c3f82",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101817975,
-    "wof:lastmodified":1566597938,
+    "wof:lastmodified":1582348268,
     "wof:name":"Vilkija",
     "wof:parent_id":102073625,
     "wof:placetype":"locality",

--- a/data/101/817/977/101817977.geojson
+++ b/data/101/817/977/101817977.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Kudirkos Naumiestis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca72444657f3912f33bdf8e7ebd9407f",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101817977,
-    "wof:lastmodified":1566597930,
+    "wof:lastmodified":1582348267,
     "wof:name":"Kudirkos Naumiestis",
     "wof:parent_id":102073619,
     "wof:placetype":"locality",

--- a/data/101/817/983/101817983.geojson
+++ b/data/101/817/983/101817983.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Gelgaudi\u0161kis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54f1bed1a070ae4c2ec54c1967de8a0a",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101817983,
-    "wof:lastmodified":1566597930,
+    "wof:lastmodified":1582348267,
     "wof:name":"Gelgaudi\u0161kis",
     "wof:parent_id":102073619,
     "wof:placetype":"locality",

--- a/data/101/817/985/101817985.geojson
+++ b/data/101/817/985/101817985.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Rum\u0161i\u0161k\u0117s"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"15b267d7626c73e03ac185b74c93260c",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101817985,
-    "wof:lastmodified":1566597931,
+    "wof:lastmodified":1582348268,
     "wof:name":"Rum\u0161i\u0161k\u0117s",
     "wof:parent_id":102073621,
     "wof:placetype":"locality",

--- a/data/101/817/987/101817987.geojson
+++ b/data/101/817/987/101817987.geojson
@@ -151,6 +151,9 @@
         "wk:page":"\u017die\u017emariai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"97593aa9e255a18819e4f69a5d2551b6",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101817987,
-    "wof:lastmodified":1566597936,
+    "wof:lastmodified":1582348268,
     "wof:name":"\u017die\u017emariai",
     "wof:parent_id":102073621,
     "wof:placetype":"locality",

--- a/data/101/817/989/101817989.geojson
+++ b/data/101/817/989/101817989.geojson
@@ -152,6 +152,9 @@
         "wd:id":"Q614855"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64b9496d518c0264127dda3388a43d69",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":101817989,
-    "wof:lastmodified":1566597937,
+    "wof:lastmodified":1582348268,
     "wof:name":"Kai\u0161iadorys",
     "wof:parent_id":102073621,
     "wof:placetype":"locality",

--- a/data/101/817/991/101817991.geojson
+++ b/data/101/817/991/101817991.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Pag\u0117giai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe6aaa61f0f4527071663897bfc970f9",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101817991,
-    "wof:lastmodified":1566597927,
+    "wof:lastmodified":1582348267,
     "wof:name":"Pag\u0117giai",
     "wof:parent_id":102073623,
     "wof:placetype":"locality",

--- a/data/101/817/993/101817993.geojson
+++ b/data/101/817/993/101817993.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Kulautuva"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf24888bc61a485473dfbd8e0950ce71",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101817993,
-    "wof:lastmodified":1566597933,
+    "wof:lastmodified":1582348268,
     "wof:name":"Kulautuva",
     "wof:parent_id":102073625,
     "wof:placetype":"locality",

--- a/data/101/817/995/101817995.geojson
+++ b/data/101/817/995/101817995.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Garliava"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8b254ec0fd6667eb9a43cede9791334",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101817995,
-    "wof:lastmodified":1566597932,
+    "wof:lastmodified":1582348268,
     "wof:name":"Garliava",
     "wof:parent_id":102073625,
     "wof:placetype":"locality",

--- a/data/101/817/997/101817997.geojson
+++ b/data/101/817/997/101817997.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Karm\u0117lava"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2e427f56912367408c0752af599d7a5",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101817997,
-    "wof:lastmodified":1566597928,
+    "wof:lastmodified":1582348267,
     "wof:name":"Karm\u0117lava",
     "wof:parent_id":102073625,
     "wof:placetype":"locality",

--- a/data/101/818/007/101818007.geojson
+++ b/data/101/818/007/101818007.geojson
@@ -160,6 +160,9 @@
         "wk:page":"Nemen\u010din\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87d59024eaab384400babbfa7e0c2b09",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101818007,
-    "wof:lastmodified":1566597919,
+    "wof:lastmodified":1582348266,
     "wof:name":"Nemen\u010din\u0117",
     "wof:parent_id":102073629,
     "wof:placetype":"locality",

--- a/data/101/818/011/101818011.geojson
+++ b/data/101/818/011/101818011.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Jurbarkas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6ebc16456fc892b0f49db7e90bf2db7",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101818011,
-    "wof:lastmodified":1566597923,
+    "wof:lastmodified":1582348266,
     "wof:name":"Jurbarkas",
     "wof:parent_id":102073631,
     "wof:placetype":"locality",

--- a/data/101/818/019/101818019.geojson
+++ b/data/101/818/019/101818019.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":1010443
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a1d0265bcd690fcc1cf620ed1fb9a5b",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101818019,
-    "wof:lastmodified":1566597924,
+    "wof:lastmodified":1582348266,
     "wof:name":"Skaudvil\u0117",
     "wof:parent_id":102073637,
     "wof:placetype":"locality",

--- a/data/101/818/021/101818021.geojson
+++ b/data/101/818/021/101818021.geojson
@@ -215,6 +215,9 @@
         "wk:page":"Taurag\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44b263acf4b0b54e111274cee2e24f39",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":101818021,
-    "wof:lastmodified":1566597924,
+    "wof:lastmodified":1582348266,
     "wof:name":"Taurag\u0117",
     "wof:parent_id":102073637,
     "wof:placetype":"locality",

--- a/data/101/818/023/101818023.geojson
+++ b/data/101/818/023/101818023.geojson
@@ -261,6 +261,9 @@
         "wk:page":"Jonava"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d3140f810f341051986932d25bb2e65f",
     "wof:hierarchy":[
         {
@@ -272,7 +275,7 @@
         }
     ],
     "wof:id":101818023,
-    "wof:lastmodified":1566597916,
+    "wof:lastmodified":1582348265,
     "wof:name":"Jonava",
     "wof:parent_id":102073639,
     "wof:placetype":"locality",

--- a/data/101/818/025/101818025.geojson
+++ b/data/101/818/025/101818025.geojson
@@ -91,6 +91,9 @@
         "wk:page":"\u0160v\u0117k\u0161na"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd06a3366a2e25654897ef6fc184ecb7",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101818025,
-    "wof:lastmodified":1566597918,
+    "wof:lastmodified":1582348266,
     "wof:name":"\u0160v\u0117k\u0161na",
     "wof:parent_id":102073641,
     "wof:placetype":"locality",

--- a/data/101/818/029/101818029.geojson
+++ b/data/101/818/029/101818029.geojson
@@ -179,6 +179,9 @@
         "wk:page":"\u0160ilut\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89589cb84f22dd326e24d418770c2a12",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":101818029,
-    "wof:lastmodified":1566597923,
+    "wof:lastmodified":1582348266,
     "wof:name":"\u0160ilut\u0117",
     "wof:parent_id":102073641,
     "wof:placetype":"locality",

--- a/data/101/818/031/101818031.geojson
+++ b/data/101/818/031/101818031.geojson
@@ -102,6 +102,9 @@
         "wk:page":"\u017demai\u010di\u0173 Naumiestis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8468e51d7931bdd159d00bd50fd67029",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101818031,
-    "wof:lastmodified":1566597919,
+    "wof:lastmodified":1582348266,
     "wof:name":"\u017demai\u010di\u0173 Naumiestis",
     "wof:parent_id":102073641,
     "wof:placetype":"locality",

--- a/data/101/818/033/101818033.geojson
+++ b/data/101/818/033/101818033.geojson
@@ -96,6 +96,9 @@
         "wd:id":"Q1939758"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8c7f4d360c6bbbbad31263e3c7a852a",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101818033,
-    "wof:lastmodified":1566597925,
+    "wof:lastmodified":1582348266,
     "wof:name":"Rusn\u0117",
     "wof:parent_id":102073641,
     "wof:placetype":"locality",

--- a/data/101/818/037/101818037.geojson
+++ b/data/101/818/037/101818037.geojson
@@ -153,6 +153,9 @@
         "qs_pg:id":1165554
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec75526a48a45727b67c314e40733e00",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101818037,
-    "wof:lastmodified":1566597920,
+    "wof:lastmodified":1582348266,
     "wof:name":"Neringa (Nida)",
     "wof:parent_id":102073645,
     "wof:placetype":"locality",

--- a/data/101/818/041/101818041.geojson
+++ b/data/101/818/041/101818041.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Ariogala"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8613c260bdb4f6db4781fb45b792f46",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101818041,
-    "wof:lastmodified":1566597917,
+    "wof:lastmodified":1582348265,
     "wof:name":"Ariogala",
     "wof:parent_id":102073651,
     "wof:placetype":"locality",

--- a/data/101/818/049/101818049.geojson
+++ b/data/101/818/049/101818049.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Mol\u0117tai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2aeb00daead1f89c7a90dbcc62fa99f",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101818049,
-    "wof:lastmodified":1566597918,
+    "wof:lastmodified":1582348266,
     "wof:name":"Mol\u0117tai",
     "wof:parent_id":102073661,
     "wof:placetype":"locality",

--- a/data/101/818/051/101818051.geojson
+++ b/data/101/818/051/101818051.geojson
@@ -217,6 +217,9 @@
         "wk:page":"Ukmerg\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9bc2252ade2a5e225d882d2c8b56cc66",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":101818051,
-    "wof:lastmodified":1566597925,
+    "wof:lastmodified":1582348266,
     "wof:name":"Ukmerg\u0117",
     "wof:parent_id":102073663,
     "wof:placetype":"locality",

--- a/data/101/818/055/101818055.geojson
+++ b/data/101/818/055/101818055.geojson
@@ -145,6 +145,9 @@
         "wk:page":"\u0160ven\u010dion\u0117liai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5559865404ea29edbf0abaff32c02c97",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101818055,
-    "wof:lastmodified":1566597919,
+    "wof:lastmodified":1582348266,
     "wof:name":"\u0160ven\u010dion\u0117liai",
     "wof:parent_id":102073665,
     "wof:placetype":"locality",

--- a/data/101/818/059/101818059.geojson
+++ b/data/101/818/059/101818059.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Pabrad\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5471cab01a2958bf42012e70f57ac01b",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101818059,
-    "wof:lastmodified":1566597925,
+    "wof:lastmodified":1582348266,
     "wof:name":"Pabrad\u0117",
     "wof:parent_id":102073665,
     "wof:placetype":"locality",

--- a/data/101/818/065/101818065.geojson
+++ b/data/101/818/065/101818065.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Tytuv\u0117nai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6524b94f3a3379eda46ee62ba46ad66f",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101818065,
-    "wof:lastmodified":1566597918,
+    "wof:lastmodified":1582348266,
     "wof:name":"Tytuv\u0117nai",
     "wof:parent_id":102073673,
     "wof:placetype":"locality",

--- a/data/101/818/067/101818067.geojson
+++ b/data/101/818/067/101818067.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Baisogala"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afd510803ad751af82de9d67a937ddd1",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101818067,
-    "wof:lastmodified":1566597926,
+    "wof:lastmodified":1582348267,
     "wof:name":"Baisogala",
     "wof:parent_id":102073679,
     "wof:placetype":"locality",

--- a/data/101/818/069/101818069.geojson
+++ b/data/101/818/069/101818069.geojson
@@ -190,6 +190,9 @@
         "wk:page":"Radvili\u0161kis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b55a10766b53bd7908021feb0245c4ac",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":101818069,
-    "wof:lastmodified":1566597925,
+    "wof:lastmodified":1582348266,
     "wof:name":"Radvili\u0161kis",
     "wof:parent_id":102073679,
     "wof:placetype":"locality",

--- a/data/101/818/079/101818079.geojson
+++ b/data/101/818/079/101818079.geojson
@@ -164,6 +164,9 @@
         "wd:id":"Q505416"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c02c77fed7868ab9ed11921e0f89521",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101818079,
-    "wof:lastmodified":1566597917,
+    "wof:lastmodified":1582348265,
     "wof:name":"Anyk\u0161\u010diai",
     "wof:parent_id":102073687,
     "wof:placetype":"locality",

--- a/data/101/818/081/101818081.geojson
+++ b/data/101/818/081/101818081.geojson
@@ -238,6 +238,9 @@
         "wk:page":"Utena"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ac22a2ef81aca3985fb59f49176c10a",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         }
     ],
     "wof:id":101818081,
-    "wof:lastmodified":1566597923,
+    "wof:lastmodified":1582348266,
     "wof:name":"Utena",
     "wof:parent_id":102073693,
     "wof:placetype":"locality",

--- a/data/101/818/083/101818083.geojson
+++ b/data/101/818/083/101818083.geojson
@@ -195,6 +195,9 @@
         "wk:page":"Plung\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b99d6fbf69ca9568e0ff54d4e0ee6e27",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":101818083,
-    "wof:lastmodified":1566597917,
+    "wof:lastmodified":1582348265,
     "wof:name":"Plung\u0117",
     "wof:parent_id":102073695,
     "wof:placetype":"locality",

--- a/data/101/818/085/101818085.geojson
+++ b/data/101/818/085/101818085.geojson
@@ -239,6 +239,9 @@
         "wk:page":"Tel\u0161iai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d033e0eea12328633e8d39d993a2d4a8",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
         }
     ],
     "wof:id":101818085,
-    "wof:lastmodified":1566597918,
+    "wof:lastmodified":1582348266,
     "wof:name":"Tel\u0161iai",
     "wof:parent_id":102073699,
     "wof:placetype":"locality",

--- a/data/101/818/087/101818087.geojson
+++ b/data/101/818/087/101818087.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Varniai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a285eb14c1011fdb2b946ac469b453b5",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101818087,
-    "wof:lastmodified":1566597922,
+    "wof:lastmodified":1582348266,
     "wof:name":"Varniai",
     "wof:parent_id":102073699,
     "wof:placetype":"locality",

--- a/data/101/818/091/101818091.geojson
+++ b/data/101/818/091/101818091.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Krekenava"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b4c409495114fa9f44aeea938960047",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101818091,
-    "wof:lastmodified":1566597918,
+    "wof:lastmodified":1582348266,
     "wof:name":"Krekenava",
     "wof:parent_id":102073701,
     "wof:placetype":"locality",

--- a/data/101/818/093/101818093.geojson
+++ b/data/101/818/093/101818093.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Ramygala"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ce1e72931ae7f86292100f72eb313dea",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101818093,
-    "wof:lastmodified":1566597926,
+    "wof:lastmodified":1582348267,
     "wof:name":"Ramygala",
     "wof:parent_id":102073701,
     "wof:placetype":"locality",

--- a/data/101/818/095/101818095.geojson
+++ b/data/101/818/095/101818095.geojson
@@ -167,6 +167,9 @@
         "wd:id":"Q820024"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff329e4af64c0c3ebbafc9b6a009f406",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":101818095,
-    "wof:lastmodified":1566597924,
+    "wof:lastmodified":1582348266,
     "wof:name":"Kupi\u0161kis",
     "wof:parent_id":102073705,
     "wof:placetype":"locality",

--- a/data/101/818/097/101818097.geojson
+++ b/data/101/818/097/101818097.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Dusetos"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b72b1d60523c9430adae5bcf45580f0",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101818097,
-    "wof:lastmodified":1566597920,
+    "wof:lastmodified":1582348266,
     "wof:name":"Dusetos",
     "wof:parent_id":102073709,
     "wof:placetype":"locality",

--- a/data/101/818/099/101818099.geojson
+++ b/data/101/818/099/101818099.geojson
@@ -169,6 +169,9 @@
         "wd:id":"Q147750"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd90d1fc61aef7536a9dfe7777ddec14",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":101818099,
-    "wof:lastmodified":1566597919,
+    "wof:lastmodified":1582348266,
     "wof:name":"Zarasai",
     "wof:parent_id":102073709,
     "wof:placetype":"locality",

--- a/data/101/818/103/101818103.geojson
+++ b/data/101/818/103/101818103.geojson
@@ -145,6 +145,9 @@
         "wd:id":"Q1004290"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab1daf19f5ad1e456447ad4d7bc4ddda",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101818103,
-    "wof:lastmodified":1566597916,
+    "wof:lastmodified":1582348265,
     "wof:name":"Skuodas",
     "wof:parent_id":102073711,
     "wof:placetype":"locality",

--- a/data/101/818/105/101818105.geojson
+++ b/data/101/818/105/101818105.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Seda, Lithuania"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c1ab690495fe500ccc692238d658fc4",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101818105,
-    "wof:lastmodified":1566597916,
+    "wof:lastmodified":1582348265,
     "wof:name":"Seda",
     "wof:parent_id":102073713,
     "wof:placetype":"locality",

--- a/data/101/818/109/101818109.geojson
+++ b/data/101/818/109/101818109.geojson
@@ -214,6 +214,9 @@
         "wd:id":"Q203675"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f06d303b7b2241e57cfc89af5bbfa922",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":101818109,
-    "wof:lastmodified":1566597922,
+    "wof:lastmodified":1582348266,
     "wof:name":"Ma\u017eeikiai",
     "wof:parent_id":102073713,
     "wof:placetype":"locality",

--- a/data/101/818/111/101818111.geojson
+++ b/data/101/818/111/101818111.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Venta"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"145328839b425f78ead79d2d174e81a1",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101818111,
-    "wof:lastmodified":1566597921,
+    "wof:lastmodified":1582348266,
     "wof:name":"Venta",
     "wof:parent_id":102073715,
     "wof:placetype":"locality",

--- a/data/101/818/117/101818117.geojson
+++ b/data/101/818/117/101818117.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Pakruojis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96971cc94c53435038674d7c3f1ccd57",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101818117,
-    "wof:lastmodified":1566597922,
+    "wof:lastmodified":1582348266,
     "wof:name":"Pakruojis",
     "wof:parent_id":102073717,
     "wof:placetype":"locality",

--- a/data/101/818/119/101818119.geojson
+++ b/data/101/818/119/101818119.geojson
@@ -143,6 +143,9 @@
         "wd:id":"Q945484"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3f5083c16028686f0f4603eaa4de08f",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":101818119,
-    "wof:lastmodified":1566597921,
+    "wof:lastmodified":1582348266,
     "wof:name":"Pasvalys",
     "wof:parent_id":102073719,
     "wof:placetype":"locality",

--- a/data/101/818/121/101818121.geojson
+++ b/data/101/818/121/101818121.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Juodup\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cdb4ce89ee0603c4a0485ffc253e1bca",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101818121,
-    "wof:lastmodified":1566597921,
+    "wof:lastmodified":1582348266,
     "wof:name":"Juodup\u0117",
     "wof:parent_id":102073721,
     "wof:placetype":"locality",

--- a/data/101/818/123/101818123.geojson
+++ b/data/101/818/123/101818123.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Pand\u0117lys"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"855cdd1f13cf0d597bc4fd1b2e95563c",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101818123,
-    "wof:lastmodified":1566597926,
+    "wof:lastmodified":1582348267,
     "wof:name":"Pand\u0117lys",
     "wof:parent_id":102073721,
     "wof:placetype":"locality",

--- a/data/101/818/127/101818127.geojson
+++ b/data/101/818/127/101818127.geojson
@@ -182,6 +182,9 @@
         "wd:id":"Q1693963"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8994874bf9eeaffc50dbf4e5e2780d41",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":101818127,
-    "wof:lastmodified":1566597921,
+    "wof:lastmodified":1582348266,
     "wof:name":"Roki\u0161kis",
     "wof:parent_id":102073721,
     "wof:placetype":"locality",

--- a/data/101/818/129/101818129.geojson
+++ b/data/101/818/129/101818129.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Obeliai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58407b1d11fbc91e4f35623547bf22d7",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":101818129,
-    "wof:lastmodified":1566597920,
+    "wof:lastmodified":1582348266,
     "wof:name":"Obeliai",
     "wof:parent_id":102073721,
     "wof:placetype":"locality",

--- a/data/101/818/131/101818131.geojson
+++ b/data/101/818/131/101818131.geojson
@@ -179,6 +179,9 @@
         "wd:id":"Q847715"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f2870a5ad41788a6c57ff335e08541a",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":101818131,
-    "wof:lastmodified":1566597922,
+    "wof:lastmodified":1582348266,
     "wof:name":"Joni\u0161kis",
     "wof:parent_id":102073723,
     "wof:placetype":"locality",

--- a/data/101/818/133/101818133.geojson
+++ b/data/101/818/133/101818133.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Vabalninkas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0970bf5c4be2ab3ee6e68a70f9c062e1",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101818133,
-    "wof:lastmodified":1566597916,
+    "wof:lastmodified":1582348265,
     "wof:name":"Vabalninkas",
     "wof:parent_id":102073727,
     "wof:placetype":"locality",

--- a/data/101/818/135/101818135.geojson
+++ b/data/101/818/135/101818135.geojson
@@ -199,6 +199,9 @@
         "wk:page":"Bir\u017eai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7227f40edb03c9b1818f712c335da20",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":101818135,
-    "wof:lastmodified":1566597916,
+    "wof:lastmodified":1582348265,
     "wof:name":"Bir\u017eai",
     "wof:parent_id":102073727,
     "wof:placetype":"locality",

--- a/data/101/847/719/101847719.geojson
+++ b/data/101/847/719/101847719.geojson
@@ -211,6 +211,9 @@
         "wk:page":"Druskininkai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f0bd720bd81d9730c9dd40333dc6513",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":101847719,
-    "wof:lastmodified":1566597939,
+    "wof:lastmodified":1582348269,
     "wof:name":"Druskininkai",
     "wof:parent_id":102073579,
     "wof:placetype":"locality",

--- a/data/101/847/731/101847731.geojson
+++ b/data/101/847/731/101847731.geojson
@@ -131,6 +131,9 @@
         "wd:id":"Q20990"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"190863d0134d1e03308910e8c31c7e0d",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101847731,
-    "wof:lastmodified":1566597939,
+    "wof:lastmodified":1582348269,
     "wof:name":"Neringa (Juodkrant\u0117)",
     "wof:parent_id":102073645,
     "wof:placetype":"locality",

--- a/data/101/847/733/101847733.geojson
+++ b/data/101/847/733/101847733.geojson
@@ -158,6 +158,9 @@
         "wk:page":"Kur\u0161\u0117nai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02dafe879358828f35246a718d88b63c",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":101847733,
-    "wof:lastmodified":1566597939,
+    "wof:lastmodified":1582348269,
     "wof:name":"Kur\u0161\u0117nai",
     "wof:parent_id":102073703,
     "wof:placetype":"locality",

--- a/data/101/913/109/101913109.geojson
+++ b/data/101/913/109/101913109.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Pal\u016b\u0161\u0117"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fe74010490e016ef8d3847988b7d992",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101913109,
-    "wof:lastmodified":1566597938,
+    "wof:lastmodified":1582348269,
     "wof:name":"Pal\u016b\u0161\u0117",
     "wof:parent_id":102073685,
     "wof:placetype":"locality",

--- a/data/856/332/69/85633269.geojson
+++ b/data/856/332/69/85633269.geojson
@@ -1189,6 +1189,11 @@
     },
     "wof:country":"LT",
     "wof:country_alpha3":"LTU",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"6b2aeff601da2affcdd651525326cb0d",
     "wof:hierarchy":[
         {
@@ -1203,7 +1208,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1566596907,
+    "wof:lastmodified":1582348250,
     "wof:name":"Lithuania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/858/977/45/85897745.geojson
+++ b/data/858/977/45/85897745.geojson
@@ -162,6 +162,10 @@
         "wk:page":"Grigi\u0161k\u0117s"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0647f89dca9cc235fd4f156f07f8c3d",
     "wof:hierarchy":[
         {
@@ -177,7 +181,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596908,
+    "wof:lastmodified":1582348250,
     "wof:name":"Grigiskes",
     "wof:parent_id":101754089,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/47/85897747.geojson
+++ b/data/858/977/47/85897747.geojson
@@ -130,6 +130,10 @@
         "wk:page":"Naujoji Vilnia"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2c9ff0cfde2967a133c3925eb8b1e4c",
     "wof:hierarchy":[
         {
@@ -145,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596908,
+    "wof:lastmodified":1582348250,
     "wof:name":"Naujoji Vilnia",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/49/85897749.geojson
+++ b/data/858/977/49/85897749.geojson
@@ -121,6 +121,10 @@
         "wd:id":"Q1390465"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55eb94439457b9e5ca9c008f9d9f4f9c",
     "wof:hierarchy":[
         {
@@ -136,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596908,
+    "wof:lastmodified":1582348250,
     "wof:name":"Fabijoniskes",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/17/85929117.geojson
+++ b/data/859/291/17/85929117.geojson
@@ -106,6 +106,10 @@
         "wk:page":"\u0160nipi\u0161k\u0117s"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"68db79743838a103054931dc2a455341",
     "wof:hierarchy":[
         {
@@ -121,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Snipiskes",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/21/85929121.geojson
+++ b/data/859/291/21/85929121.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Naujininkai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4152a2be5af54ea089c363e06ae9e1e",
     "wof:hierarchy":[
         {
@@ -124,7 +128,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596904,
+    "wof:lastmodified":1582348249,
     "wof:name":"Naujininkai",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/25/85929125.geojson
+++ b/data/859/291/25/85929125.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Antakalnis"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ec809b2a0f7833f7f82cd345924ec2f",
     "wof:hierarchy":[
         {
@@ -130,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596904,
+    "wof:lastmodified":1582348250,
     "wof:name":"Antakalnis",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/31/85929131.geojson
+++ b/data/859/291/31/85929131.geojson
@@ -157,6 +157,10 @@
         "wk:page":"Vepriai"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3eec2bbca75ead748cada6b500e6aa02",
     "wof:hierarchy":[
         {
@@ -172,7 +176,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596904,
+    "wof:lastmodified":1582348249,
     "wof:name":"Verkiai",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/85/85929185.geojson
+++ b/data/859/291/85/85929185.geojson
@@ -104,6 +104,10 @@
         "wd:id":"Q2577081"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c4c19d0e542204bb5a9c534eed4b779",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596904,
+    "wof:lastmodified":1582348250,
     "wof:name":"Vilkpede",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/89/85929189.geojson
+++ b/data/859/291/89/85929189.geojson
@@ -134,6 +134,10 @@
         "wd:id":"Q708092"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"86734aa70903e01f54eac59129c16edf",
     "wof:hierarchy":[
         {
@@ -149,7 +153,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Aukstieji Paneriai",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/93/85929193.geojson
+++ b/data/859/291/93/85929193.geojson
@@ -105,6 +105,10 @@
         "wd:id":"Q1260423"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e15be85515e22c2a026f60b6e6c9937",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Justiniskes",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/291/97/85929197.geojson
+++ b/data/859/291/97/85929197.geojson
@@ -103,6 +103,10 @@
         "wd:id":"Q1507762"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4089d0741795227599b579396eaddc08",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596904,
+    "wof:lastmodified":1582348249,
     "wof:name":"Pasilaiciai",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/05/85929205.geojson
+++ b/data/859/292/05/85929205.geojson
@@ -89,6 +89,10 @@
         "qs_pg:id":1091108
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b44b64d4ab3905cdc98e512e8f53fb3",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Zirmunai",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/09/85929209.geojson
+++ b/data/859/292/09/85929209.geojson
@@ -105,6 +105,10 @@
         "wd:id":"Q1514004"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"baa86c467aa6cecacb6e2752445a5d39",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Karoliniskes",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/11/85929211.geojson
+++ b/data/859/292/11/85929211.geojson
@@ -103,6 +103,10 @@
         "wd:id":"Q1005578"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ac716c15968bfcd9829ec304b8978b5",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Pilaite",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/15/85929215.geojson
+++ b/data/859/292/15/85929215.geojson
@@ -105,6 +105,10 @@
         "wk:page":"\u017dv\u0117rynas"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"589d2002a0bc54f99c4d8d934ae612f5",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Zverynas",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/21/85929221.geojson
+++ b/data/859/292/21/85929221.geojson
@@ -121,6 +121,10 @@
         "wd:id":"Q1646619"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce2fd9679c330939dc3e1f4ce2eb5a4b",
     "wof:hierarchy":[
         {
@@ -136,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Lazdynai",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/25/85929225.geojson
+++ b/data/859/292/25/85929225.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1310966
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"84c6a63ab0bb5ca3a09584fb53c52ded",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Rasos",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/29/85929229.geojson
+++ b/data/859/292/29/85929229.geojson
@@ -144,6 +144,10 @@
         "wd:id":"Q445649"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fc34508e6ab1865553ac75bad4457b1",
     "wof:hierarchy":[
         {
@@ -159,7 +163,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Senamiestis",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/33/85929233.geojson
+++ b/data/859/292/33/85929233.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":216185
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"93977aae57f3721d7e3072163e85231e",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Naujamiestis",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",

--- a/data/859/292/39/85929239.geojson
+++ b/data/859/292/39/85929239.geojson
@@ -102,6 +102,10 @@
         "wd:id":"Q2455066"
     },
     "wof:country":"LT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4e5d97a9b80041d2a6f79590a3d9aed",
     "wof:hierarchy":[
         {
@@ -117,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566596903,
+    "wof:lastmodified":1582348249,
     "wof:name":"Seskine",
     "wof:parent_id":101753031,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.