### PR TITLE
Change preferred name of Marijampole in Lithuanian

### DIFF
--- a/data/101/752/743/101752743.geojson
+++ b/data/101/752/743/101752743.geojson
@@ -121,9 +121,6 @@
         "Kapsukas"
     ],
     "name:lit_x_preferred":[
-        "Kapsukas"
-    ],
-    "name:lit_x_variant":[
         "Marijampol\u0117"
     ],
     "name:ltg_x_preferred":[


### PR DESCRIPTION
The current city name is Marijampolė. Kapsukas hasn't been this city's name since 1989.

https://en.wikipedia.org/wiki/Marijampol%C4%97#Names