### PR TITLE
lt concordances, placetype local, and more

### DIFF
--- a/data/102/073/579/102073579.geojson
+++ b/data/102/073/579/102073579.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":19122,
     "eurostat:population_year":2020,
     "geom:area":0.062242,
-    "geom:area_square_m":451958574.321281,
+    "geom:area_square_m":451958641.541374,
     "geom:bbox":"23.798739,53.92416,24.20493,54.180676",
     "geom:latitude":54.038395,
     "geom:longitude":23.986379,
@@ -170,10 +170,16 @@
         "eg:gisco_id":"LT_15",
         "eurostat:nuts_2021_id":"15",
         "hasc:id":"LT.AS.DR",
+        "iso:code":"LT-07",
+        "qs:local_id":"115",
         "wd:id":"Q669649"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"241091990d48195a84dd975d564010ff",
+    "wof:geomhash":"17c39caf9aaae1c781972cf755d69d53",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -183,7 +189,7 @@
         }
     ],
     "wof:id":102073579,
-    "wof:lastmodified":1690938616,
+    "wof:lastmodified":1695886741,
     "wof:name":"Druskininkai",
     "wof:parent_id":85685765,
     "wof:placetype":"county",

--- a/data/102/073/583/102073583.geojson
+++ b/data/102/073/583/102073583.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":18324,
     "eurostat:population_year":2020,
     "geom:area":0.180083,
-    "geom:area_square_m":1303422673.309679,
+    "geom:area_square_m":1303422614.53127,
     "geom:bbox":"23.312414,53.898873,23.983542,54.423702",
     "geom:latitude":54.17267,
     "geom:longitude":23.640008,
@@ -164,10 +164,16 @@
         "eg:gisco_id":"LT_59",
         "eurostat:nuts_2021_id":"59",
         "hasc:id":"LT.AS.LA",
+        "iso:code":"LT-24",
+        "qs:local_id":"159",
         "wd:id":"Q2069342"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"df1cd8d45ef419807f03e0381a58944e",
+    "wof:geomhash":"3200ab736dfce25309b9faa1de8afd71",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +183,7 @@
         }
     ],
     "wof:id":102073583,
-    "wof:lastmodified":1690938616,
+    "wof:lastmodified":1695886741,
     "wof:name":"Lazdijai",
     "wof:parent_id":85685765,
     "wof:placetype":"county",

--- a/data/102/073/585/102073585.geojson
+++ b/data/102/073/585/102073585.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":10187,
     "eurostat:population_year":2020,
     "geom:area":0.061003,
-    "geom:area_square_m":439327814.094995,
+    "geom:area_square_m":439327588.577142,
     "geom:bbox":"22.989625,54.253323,23.401077,54.488513",
     "geom:latitude":54.378923,
     "geom:longitude":23.196235,
@@ -165,10 +165,16 @@
         "eg:gisco_id":"LT_48",
         "eurostat:nuts_2021_id":"48",
         "hasc:id":"LT.MA.KV",
+        "iso:code":"LT-14",
+        "qs:local_id":"448",
         "wd:id":"Q1461987"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"bb4d6d37a42877c9231597253e41fd15",
+    "wof:geomhash":"0faddaa95e74c4dee8392bab48e4f1e5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -178,7 +184,7 @@
         }
     ],
     "wof:id":102073585,
-    "wof:lastmodified":1690938614,
+    "wof:lastmodified":1695886741,
     "wof:name":"Kalvarija",
     "wof:parent_id":85685753,
     "wof:placetype":"county",

--- a/data/102/073/589/102073589.geojson
+++ b/data/102/073/589/102073589.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":20844,
     "eurostat:population_year":2020,
     "geom:area":0.305441,
-    "geom:area_square_m":2210519496.300067,
+    "geom:area_square_m":2210519956.804256,
     "geom:bbox":"23.960643,53.897053,25.02479,54.44764",
     "geom:latitude":54.176924,
     "geom:longitude":24.499986,
@@ -189,10 +189,16 @@
         "eg:gisco_id":"LT_38",
         "eurostat:nuts_2021_id":"38",
         "hasc:id":"LT.AS.VR",
+        "iso:code":"LT-55",
+        "qs:local_id":"138",
         "wd:id":"Q1351747"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"d1d52fb265b2b658e77466981e35d772",
+    "wof:geomhash":"4de0949767c2781094337aa0ba3447b6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -202,7 +208,7 @@
         }
     ],
     "wof:id":102073589,
-    "wof:lastmodified":1690938610,
+    "wof:lastmodified":1695886741,
     "wof:name":"Varena",
     "wof:parent_id":85685765,
     "wof:placetype":"county",

--- a/data/102/073/593/102073593.geojson
+++ b/data/102/073/593/102073593.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":4066,
     "eurostat:population_year":2020,
     "geom:area":0.016905,
-    "geom:area_square_m":121190038.871542,
+    "geom:area_square_m":121190028.223287,
     "geom:bbox":"23.885839,54.49064,24.172392,54.64855",
     "geom:latitude":54.565057,
     "geom:longitude":24.021092,
@@ -186,10 +186,16 @@
         "eg:gisco_id":"LT_12",
         "eurostat:nuts_2021_id":"12",
         "hasc:id":"LT.KS.BS",
+        "iso:code":"LT-05",
+        "qs:local_id":"212",
         "wd:id":"Q2015893"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"064e1bb9b06267e277d3fa16733c44a3",
+    "wof:geomhash":"b13b381d385d2b4c4ae205f5279a106e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -199,7 +205,7 @@
         }
     ],
     "wof:id":102073593,
-    "wof:lastmodified":1690938604,
+    "wof:lastmodified":1695886741,
     "wof:name":"Bir\u0161tonas",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/595/102073595.geojson
+++ b/data/102/073/595/102073595.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_18",
         "eurostat:nuts_2021_id":"18",
-        "hasc:id":"LT.MA.MM"
+        "hasc:id":"LT.MA.MM",
+        "iso:code":"LT-25",
+        "qs:local_id":"418"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"fc31c4bcb103fad481284ca2e85c8cae",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073595,
-    "wof:lastmodified":1684353992,
+    "wof:lastmodified":1695886741,
     "wof:name":"Marijampole",
     "wof:parent_id":85685753,
     "wof:placetype":"county",

--- a/data/102/073/597/102073597.geojson
+++ b/data/102/073/597/102073597.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":30521,
     "eurostat:population_year":2020,
     "geom:area":0.206215,
-    "geom:area_square_m":1487388808.099216,
+    "geom:area_square_m":1487388648.358764,
     "geom:bbox":"24.756055,54.127403,25.788641,54.50713",
     "geom:latitude":54.315984,
     "geom:longitude":25.273235,
@@ -174,10 +174,16 @@
         "eg:gisco_id":"LT_85",
         "eurostat:nuts_2021_id":"85",
         "hasc:id":"LT.VI.SC",
+        "iso:code":"LT-42",
+        "qs:local_id":"085",
         "wd:id":"Q1799182"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"de715ab375af5b9bc1c30a751fe9f6fb",
+    "wof:geomhash":"af839118061191957f8bfa93b34726ad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +193,7 @@
         }
     ],
     "wof:id":102073597,
-    "wof:lastmodified":1690938610,
+    "wof:lastmodified":1695886741,
     "wof:name":"\u0160alcininkai",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/601/102073601.geojson
+++ b/data/102/073/601/102073601.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":34666,
     "eurostat:population_year":2020,
     "geom:area":0.176205,
-    "geom:area_square_m":1262297642.961407,
+    "geom:area_square_m":1262297881.611449,
     "geom:bbox":"22.680382,54.363334,23.34728,54.790728",
     "geom:latitude":54.595195,
     "geom:longitude":22.969004,
@@ -181,10 +181,16 @@
         "eg:gisco_id":"LT_39",
         "eurostat:nuts_2021_id":"39",
         "hasc:id":"LT.MA.VK",
+        "iso:code":"LT-56",
+        "qs:local_id":"439",
         "wd:id":"Q2021318"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"693d13dec112c4f2573f1623dc989955",
+    "wof:geomhash":"154c90ea897c65253109ad5288975fd3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -194,7 +200,7 @@
         }
     ],
     "wof:id":102073601,
-    "wof:lastmodified":1690938613,
+    "wof:lastmodified":1695886741,
     "wof:name":"Vilkavi\u0161kis",
     "wof:parent_id":85685753,
     "wof:placetype":"county",

--- a/data/102/073/603/102073603.geojson
+++ b/data/102/073/603/102073603.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":25806,
     "eurostat:population_year":2020,
     "geom:area":0.143729,
-    "geom:area_square_m":1028583594.829693,
+    "geom:area_square_m":1028583574.11276,
     "geom:bbox":"23.585644,54.454694,24.488275,54.811825",
     "geom:latitude":54.636984,
     "geom:longitude":23.97913,
@@ -163,10 +163,16 @@
         "eg:gisco_id":"LT_69",
         "eurostat:nuts_2021_id":"69",
         "hasc:id":"LT.KS.PR",
+        "iso:code":"LT-36",
+        "qs:local_id":"269",
         "wd:id":"Q47090"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"9e17ca7f533f104841ae7ae3f265d8ea",
+    "wof:geomhash":"9245c6d6c3d8283f3ed975120bd62642",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -176,7 +182,7 @@
         }
     ],
     "wof:id":102073603,
-    "wof:lastmodified":1690938608,
+    "wof:lastmodified":1695886741,
     "wof:name":"Prienai",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/605/102073605.geojson
+++ b/data/102/073/605/102073605.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":32541,
     "eurostat:population_year":2020,
     "geom:area":0.167673,
-    "geom:area_square_m":1202486128.057717,
+    "geom:area_square_m":1202485863.078714,
     "geom:bbox":"24.393722,54.388384,25.169257,54.739352",
     "geom:latitude":54.550609,
     "geom:longitude":24.782184,
@@ -164,10 +164,16 @@
         "eg:gisco_id":"LT_79",
         "eurostat:nuts_2021_id":"79",
         "hasc:id":"LT.VI.TK",
+        "iso:code":"LT-52",
+        "qs:local_id":"079",
         "wd:id":"Q1987743"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"55eede85a9b811a974501ea3c065c07d",
+    "wof:geomhash":"5b0cfeef94324d865c5eb8192cb8f1cf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +183,7 @@
         }
     ],
     "wof:id":102073605,
-    "wof:lastmodified":1690938606,
+    "wof:lastmodified":1695886741,
     "wof:name":"Trakai",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/607/102073607.geojson
+++ b/data/102/073/607/102073607.geojson
@@ -80,8 +80,14 @@
         "eg:gisco_id":"LT_58",
         "eurostat:nuts_2021_id":"58",
         "gp:id":55848075,
-        "hasc:id":"LT.MA.KR"
+        "hasc:id":"LT.MA.KR",
+        "iso:code":"LT-17",
+        "qs:local_id":"458"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"15813fd112f33843d694ba2ccbc93662",
     "wof:hierarchy":[
@@ -93,7 +99,7 @@
         }
     ],
     "wof:id":102073607,
-    "wof:lastmodified":1684353992,
+    "wof:lastmodified":1695886741,
     "wof:name":"Kazlu Ruda",
     "wof:parent_id":85685753,
     "wof:placetype":"county",

--- a/data/102/073/609/102073609.geojson
+++ b/data/102/073/609/102073609.geojson
@@ -43,7 +43,10 @@
         85685773
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "qs:local_id":"299"
+    },
+    "wof:concordances_official":"qs:local_id",
     "wof:country":"LT",
     "wof:geomhash":"e465968271d6aba718c1dc87717dbea7",
     "wof:hierarchy":[
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":102073609,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886953,
     "wof:name":"",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/611/102073611.geojson
+++ b/data/102/073/611/102073611.geojson
@@ -367,8 +367,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_19",
         "eurostat:nuts_2021_id":"19",
-        "hasc:id":"LT.KS.KN"
+        "hasc:id":"LT.KS.KN",
+        "iso:code":"LT-15",
+        "qs:local_id":"219"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"3b78f532d49c93b706589a4191f2abbc",
     "wof:hierarchy":[
@@ -380,7 +386,7 @@
         }
     ],
     "wof:id":102073611,
-    "wof:lastmodified":1684353992,
+    "wof:lastmodified":1695886742,
     "wof:name":"Kaunas",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/613/102073613.geojson
+++ b/data/102/073/613/102073613.geojson
@@ -80,8 +80,14 @@
         "eg:gisco_id":"LT_42",
         "eurostat:nuts_2021_id":"42",
         "gp:id":55848074,
-        "hasc:id":"LT.VI.EL"
+        "hasc:id":"LT.VI.EL",
+        "iso:code":"LT-08",
+        "qs:local_id":"042"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"4be181553c8575d8964f533628024b68",
     "wof:hierarchy":[
@@ -93,7 +99,7 @@
         }
     ],
     "wof:id":102073613,
-    "wof:lastmodified":1684353992,
+    "wof:lastmodified":1695886742,
     "wof:name":"Elektrenai",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/619/102073619.geojson
+++ b/data/102/073/619/102073619.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":26707,
     "eurostat:population_year":2020,
     "geom:area":0.203654,
-    "geom:area_square_m":1446288409.606789,
+    "geom:area_square_m":1446288684.84558,
     "geom:bbox":"22.588819,54.724688,23.589393,55.104864",
     "geom:latitude":54.947357,
     "geom:longitude":23.081444,
@@ -181,10 +181,16 @@
         "eg:gisco_id":"LT_84",
         "eurostat:nuts_2021_id":"84",
         "hasc:id":"LT.MA.SK",
+        "iso:code":"LT-41",
+        "qs:local_id":"484",
         "wd:id":"Q2021307"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"d4f85e89462e2c92a44c76e2bfdb1b4f",
+    "wof:geomhash":"1a2429e6b342487a7d50d976ba384688",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -194,7 +200,7 @@
         }
     ],
     "wof:id":102073619,
-    "wof:lastmodified":1690938605,
+    "wof:lastmodified":1695886742,
     "wof:name":"\u0160akiai",
     "wof:parent_id":85685753,
     "wof:placetype":"county",

--- a/data/102/073/621/102073621.geojson
+++ b/data/102/073/621/102073621.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":29526,
     "eurostat:population_year":2020,
     "geom:area":0.151951,
-    "geom:area_square_m":1082094918.08523,
+    "geom:area_square_m":1082094630.668538,
     "geom:bbox":"24.082871,54.628451,24.811578,55.025739",
     "geom:latitude":54.835968,
     "geom:longitude":24.411411,
@@ -187,10 +187,16 @@
         "eg:gisco_id":"LT_49",
         "eurostat:nuts_2021_id":"49",
         "hasc:id":"LT.KS.KA",
+        "iso:code":"LT-13",
+        "qs:local_id":"249",
         "wd:id":"Q2069320"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"f67f950aaaa7d7e4442cb885d327dd7b",
+    "wof:geomhash":"08b93e52bd527da88e0af9e0540fd11a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -200,7 +206,7 @@
         }
     ],
     "wof:id":102073621,
-    "wof:lastmodified":1690938605,
+    "wof:lastmodified":1695886742,
     "wof:name":"Kai\u0161iadorys",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/623/102073623.geojson
+++ b/data/102/073/623/102073623.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":7285,
     "eurostat:population_year":2020,
     "geom:area":0.075425,
-    "geom:area_square_m":532971120.939583,
+    "geom:area_square_m":532971079.790271,
     "geom:bbox":"21.649932,55.02412,22.30815,55.296473",
     "geom:latitude":55.14747,
     "geom:longitude":21.978899,
@@ -199,10 +199,16 @@
         "eurostat:nuts_2021_id":"63",
         "gp:id":55848077,
         "hasc:id":"LT.TG.PE",
+        "iso:code":"LT-29",
+        "qs:local_id":"763",
         "wd:id":"Q643376"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"01fc8189d6b95bb7781034683395d4c3",
+    "wof:geomhash":"529883afd92334c456330c77abff407a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -212,7 +218,7 @@
         }
     ],
     "wof:id":102073623,
-    "wof:lastmodified":1690938612,
+    "wof:lastmodified":1695886742,
     "wof:name":"Pagegiai",
     "wof:parent_id":85685767,
     "wof:placetype":"county",

--- a/data/102/073/625/102073625.geojson
+++ b/data/102/073/625/102073625.geojson
@@ -367,8 +367,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_52",
         "eurostat:nuts_2021_id":"52",
-        "hasc:id":"LT.KS.KU"
+        "hasc:id":"LT.KS.KU",
+        "iso:code":"LT-16",
+        "qs:local_id":"252"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"0a5ef7e03a9189e41a89bda428411c99",
     "wof:hierarchy":[
@@ -380,7 +386,7 @@
         }
     ],
     "wof:id":102073625,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886742,
     "wof:name":"Kaunas",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/627/102073627.geojson
+++ b/data/102/073/627/102073627.geojson
@@ -44,8 +44,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "gp:id":2346085
+        "gp:id":2346085,
+        "qs:local_id":"397"
     },
+    "wof:concordances_official":"qs:local_id",
     "wof:country":"LT",
     "wof:geomhash":"463cdfd0d912ed9f233023fa2e9ae3ec",
     "wof:hierarchy":[
@@ -57,7 +59,7 @@
         }
     ],
     "wof:id":102073627,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886953,
     "wof:name":"",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/629/102073629.geojson
+++ b/data/102/073/629/102073629.geojson
@@ -591,8 +591,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_41",
         "eurostat:nuts_2021_id":"41",
-        "hasc:id":"LT.VI.VL"
+        "hasc:id":"LT.VI.VL",
+        "iso:code":"LT-58",
+        "qs:local_id":"041"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"fd5e7275163349a86a962001ac1d63e5",
     "wof:hierarchy":[
@@ -604,7 +610,7 @@
         }
     ],
     "wof:id":102073629,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886742,
     "wof:name":"Vilnius",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/631/102073631.geojson
+++ b/data/102/073/631/102073631.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":24835,
     "eurostat:population_year":2020,
     "geom:area":0.212442,
-    "geom:area_square_m":1499952867.062678,
+    "geom:area_square_m":1499952988.423872,
     "geom:bbox":"22.2597,55.044388,23.504275,55.389929",
     "geom:latitude":55.180021,
     "geom:longitude":22.887835,
@@ -161,10 +161,16 @@
         "eg:gisco_id":"LT_94",
         "eurostat:nuts_2021_id":"94",
         "hasc:id":"LT.TG.JR",
+        "iso:code":"LT-12",
+        "qs:local_id":"794",
         "wd:id":"Q2089815"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"854829a79cd3b3d512e413591ac4ac9d",
+    "wof:geomhash":"a2bb84f979ef5a954eb39c65c7bda828",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -174,7 +180,7 @@
         }
     ],
     "wof:id":102073631,
-    "wof:lastmodified":1690938614,
+    "wof:lastmodified":1695886742,
     "wof:name":"Jurbarkas",
     "wof:parent_id":85685767,
     "wof:placetype":"county",

--- a/data/102/073/633/102073633.geojson
+++ b/data/102/073/633/102073633.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":15072,
     "eurostat:population_year":2020,
     "geom:area":0.127173,
-    "geom:area_square_m":901706977.611984,
+    "geom:area_square_m":901706865.746301,
     "geom:bbox":"24.553631,54.859473,25.235812,55.159702",
     "geom:latitude":55.011332,
     "geom:longitude":24.920494,
@@ -186,10 +186,16 @@
         "eg:gisco_id":"LT_89",
         "eurostat:nuts_2021_id":"89",
         "hasc:id":"LT.VI.ST",
+        "iso:code":"LT-47",
+        "qs:local_id":"089",
         "wd:id":"Q58882"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"12514b4e19b5e4b1d272de2e0d680dc8",
+    "wof:geomhash":"b6c96a2d1a23077c481bd5fea68b6e64",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -199,7 +205,7 @@
         }
     ],
     "wof:id":102073633,
-    "wof:lastmodified":1690938606,
+    "wof:lastmodified":1695886742,
     "wof:name":"\u0160irvintos",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/637/102073637.geojson
+++ b/data/102/073/637/102073637.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_77",
         "eurostat:nuts_2021_id":"77",
-        "hasc:id":"LT.TG.TA"
+        "hasc:id":"LT.TG.TA",
+        "iso:code":"LT-50",
+        "qs:local_id":"777"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"6dd5df1b1e70dac4288b15bc11cbd97f",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073637,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886742,
     "wof:name":"Taurage",
     "wof:parent_id":85685767,
     "wof:placetype":"county",

--- a/data/102/073/639/102073639.geojson
+++ b/data/102/073/639/102073639.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":41151,
     "eurostat:population_year":2020,
     "geom:area":0.132852,
-    "geom:area_square_m":939706274.34937,
+    "geom:area_square_m":939705988.97508,
     "geom:bbox":"24.015218,54.936129,24.646487,55.296961",
     "geom:latitude":55.107583,
     "geom:longitude":24.3081,
@@ -170,10 +170,16 @@
         "eg:gisco_id":"LT_46",
         "eurostat:nuts_2021_id":"46",
         "hasc:id":"LT.KS.JV",
+        "iso:code":"LT-10",
+        "qs:local_id":"246",
         "wd:id":"Q1351768"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"26b19db1a0df0a2d4e6a21bc67101723",
+    "wof:geomhash":"6344c6d8f4e71aa288c6260c5b9c706f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -183,7 +189,7 @@
         }
     ],
     "wof:id":102073639,
-    "wof:lastmodified":1690938613,
+    "wof:lastmodified":1695886742,
     "wof:name":"Jonava",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/641/102073641.geojson
+++ b/data/102/073/641/102073641.geojson
@@ -80,8 +80,14 @@
         "eg:gisco_id":"LT_88",
         "eurostat:nuts_2021_id":"88",
         "gp:id":2346085,
-        "hasc:id":"LT.KP.SE"
+        "hasc:id":"LT.KP.SE",
+        "iso:code":"LT-46",
+        "qs:local_id":"388"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"445b3bc26cbf910775e603bb36fb830f",
     "wof:hierarchy":[
@@ -93,7 +99,7 @@
         }
     ],
     "wof:id":102073641,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886742,
     "wof:name":"\u0160ilute",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/643/102073643.geojson
+++ b/data/102/073/643/102073643.geojson
@@ -43,7 +43,10 @@
         85685747
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "qs:local_id":"398"
+    },
+    "wof:concordances_official":"qs:local_id",
     "wof:country":"LT",
     "wof:geomhash":"1d0217301ce1a6d7ee205b30ad91d746",
     "wof:hierarchy":[
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":102073643,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886953,
     "wof:name":"",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/645/102073645.geojson
+++ b/data/102/073/645/102073645.geojson
@@ -88,8 +88,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_23",
         "eurostat:nuts_2021_id":"23",
-        "hasc:id":"LT.KP.NE"
+        "hasc:id":"LT.KP.NE",
+        "iso:code":"LT-28",
+        "qs:local_id":"323"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"db05579b2b1e5ebdae673b473c341e45",
     "wof:hierarchy":[
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":102073645,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Neringa",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/647/102073647.geojson
+++ b/data/102/073/647/102073647.geojson
@@ -416,8 +416,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "qs:local_id":"321",
         "wd:id":"Q776965"
     },
+    "wof:concordances_official":"qs:local_id",
     "wof:country":"LT",
     "wof:geomhash":"2acaeb974cbd0cdd617d8920ca62840d",
     "wof:hierarchy":[
@@ -429,7 +431,7 @@
         }
     ],
     "wof:id":102073647,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886740,
     "wof:name":"Klaipeda",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/649/102073649.geojson
+++ b/data/102/073/649/102073649.geojson
@@ -45,7 +45,10 @@
     "wof:breaches":[
         102073645
     ],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "qs:local_id":"399"
+    },
+    "wof:concordances_official":"qs:local_id",
     "wof:country":"LT",
     "wof:geomhash":"3d3073808687a37dc253b76d53cd6dbb",
     "wof:hierarchy":[
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":102073649,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886953,
     "wof:name":"",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/651/102073651.geojson
+++ b/data/102/073/651/102073651.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":31230,
     "eurostat:population_year":2020,
     "geom:area":0.222969,
-    "geom:area_square_m":1566193864.037713,
+    "geom:area_square_m":1566193690.610586,
     "geom:bbox":"22.67004,55.176225,23.640447,55.576743",
     "geom:latitude":55.384393,
     "geom:longitude":23.213004,
@@ -162,10 +162,16 @@
         "eg:gisco_id":"LT_72",
         "eurostat:nuts_2021_id":"72",
         "hasc:id":"LT.KS.RN",
+        "iso:code":"LT-38",
+        "qs:local_id":"272",
         "wd:id":"Q2069355"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"0ac92b1bf4d9f6e52c633a2bcbab2c30",
+    "wof:geomhash":"1d656d0ab4e9c903c8acee46d6e07ea6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -175,7 +181,7 @@
         }
     ],
     "wof:id":102073651,
-    "wof:lastmodified":1690938607,
+    "wof:lastmodified":1695886743,
     "wof:name":"Raseiniai",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/655/102073655.geojson
+++ b/data/102/073/655/102073655.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":21899,
     "eurostat:population_year":2020,
     "geom:area":0.168997,
-    "geom:area_square_m":1182780084.842267,
+    "geom:area_square_m":1182779906.54447,
     "geom:bbox":"21.808149,55.358839,22.650137,55.688293",
     "geom:latitude":55.527661,
     "geom:longitude":22.220906,
@@ -183,10 +183,16 @@
         "eg:gisco_id":"LT_87",
         "eurostat:nuts_2021_id":"87",
         "hasc:id":"LT.TG.SI",
+        "iso:code":"LT-45",
+        "qs:local_id":"787",
         "wd:id":"Q677400"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"e3ede958ddb14d8b1ecbbccf36858b6e",
+    "wof:geomhash":"e54c7e3c2a312276ccd8c8bd281ef836",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -196,7 +202,7 @@
         }
     ],
     "wof:id":102073655,
-    "wof:lastmodified":1690938613,
+    "wof:lastmodified":1695886743,
     "wof:name":"\u0160ilale",
     "wof:parent_id":85685767,
     "wof:placetype":"county",

--- a/data/102/073/657/102073657.geojson
+++ b/data/102/073/657/102073657.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":149116,
     "eurostat:population_year":2020,
     "geom:area":0.011556,
-    "geom:area_square_m":80502857.397157,
+    "geom:area_square_m":80502851.768225,
     "geom:bbox":"21.07534,55.612753,21.239835,55.796278",
     "geom:latitude":55.709487,
     "geom:longitude":21.155572,
@@ -449,10 +449,16 @@
         "eg:gisco_id":"LT_21",
         "eurostat:nuts_2021_id":"21",
         "hasc:id":"LT.KP.KC",
+        "iso:code":"LT-20",
+        "qs:local_id":"321",
         "wd:id":"Q776965"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"d11ac2e50f316ea2fcd0f60ac87d2ceb",
+    "wof:geomhash":"a07cf04820c384a48d5d9afe2f68a236",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -462,7 +468,7 @@
         }
     ],
     "wof:id":102073657,
-    "wof:lastmodified":1690938608,
+    "wof:lastmodified":1695886743,
     "wof:name":"Klaipeda",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/659/102073659.geojson
+++ b/data/102/073/659/102073659.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_53",
         "eurostat:nuts_2021_id":"53",
-        "hasc:id":"LT.KS.KD"
+        "hasc:id":"LT.KS.KD",
+        "iso:code":"LT-18",
+        "qs:local_id":"253"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"ae2a54dbe2e1f063bc4b14e5bb1f2f0d",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073659,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Kedainiai",
     "wof:parent_id":85685773,
     "wof:placetype":"county",

--- a/data/102/073/661/102073661.geojson
+++ b/data/102/073/661/102073661.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_62",
         "eurostat:nuts_2021_id":"62",
-        "hasc:id":"LT.UN.ML"
+        "hasc:id":"LT.UN.ML",
+        "iso:code":"LT-27",
+        "qs:local_id":"962"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"56a3e2121a1b95712d1174ff9bebfa8a",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073661,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Moletai",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/663/102073663.geojson
+++ b/data/102/073/663/102073663.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_81",
         "eurostat:nuts_2021_id":"81",
-        "hasc:id":"LT.VI.UK"
+        "hasc:id":"LT.VI.UK",
+        "iso:code":"LT-53",
+        "qs:local_id":"081"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"7dd96cafd89578c140bec87f9e0fc3d6",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073663,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Ukmerge",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/665/102073665.geojson
+++ b/data/102/073/665/102073665.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":22929,
     "eurostat:population_year":2020,
     "geom:area":0.238229,
-    "geom:area_square_m":1684809826.80197,
+    "geom:area_square_m":1684809170.845574,
     "geom:bbox":"25.526508,54.822219,26.759367,55.317573",
     "geom:latitude":55.113926,
     "geom:longitude":26.018291,
@@ -173,10 +173,16 @@
         "eurostat:nuts_2021_id":"86",
         "gp:id":2346088,
         "hasc:id":"LT.VI.SV",
+        "iso:code":"LT-49",
+        "qs:local_id":"086",
         "wd:id":"Q1813849"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"ba4e466470fb73e4a014fab0745ef3c0",
+    "wof:geomhash":"19a0a734f3e896251af487a30e27e155",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -186,7 +192,7 @@
         }
     ],
     "wof:id":102073665,
-    "wof:lastmodified":1690938614,
+    "wof:lastmodified":1695886743,
     "wof:name":"\u0160vencionys",
     "wof:parent_id":85685759,
     "wof:placetype":"county",

--- a/data/102/073/667/102073667.geojson
+++ b/data/102/073/667/102073667.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":60124,
     "eurostat:population_year":2020,
     "geom:area":0.176675,
-    "geom:area_square_m":1231964731.863685,
+    "geom:area_square_m":1231965370.739192,
     "geom:bbox":"21.058466,55.466174,21.882921,55.892378",
     "geom:latitude":55.6722,
     "geom:longitude":21.446099,
@@ -449,10 +449,16 @@
         "eg:gisco_id":"LT_55",
         "eurostat:nuts_2021_id":"55",
         "hasc:id":"LT.KP.KL",
+        "iso:code":"LT-21",
+        "qs:local_id":"355",
         "wd:id":"Q776965"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"97754117ba2260a1b4b2cd3d44856ce4",
+    "wof:geomhash":"64e35df7efcd242f923c69ede86de956",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -462,7 +468,7 @@
         }
     ],
     "wof:id":102073667,
-    "wof:lastmodified":1690938607,
+    "wof:lastmodified":1695886743,
     "wof:name":"Klaipeda",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/669/102073669.geojson
+++ b/data/102/073/669/102073669.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":7260,
     "eurostat:population_year":2020,
     "geom:area":0.083683,
-    "geom:area_square_m":582773073.126365,
+    "geom:area_square_m":582772765.378539,
     "geom:bbox":"21.741508,55.597018,22.255323,55.851041",
     "geom:latitude":55.722868,
     "geom:longitude":21.996812,
@@ -168,10 +168,16 @@
         "eg:gisco_id":"LT_74",
         "eurostat:nuts_2021_id":"74",
         "hasc:id":"LT.TL.RT",
+        "iso:code":"LT-39",
+        "qs:local_id":"874",
         "wd:id":"Q712011"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"00c31520476688ebdab680420566942d",
+    "wof:geomhash":"0c7e134b12da29fd8da60ed2ca4daa64",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +187,7 @@
         }
     ],
     "wof:id":102073669,
-    "wof:lastmodified":1690938607,
+    "wof:lastmodified":1695886743,
     "wof:name":"Rietavas",
     "wof:parent_id":85685741,
     "wof:placetype":"county",

--- a/data/102/073/673/102073673.geojson
+++ b/data/102/073/673/102073673.geojson
@@ -95,8 +95,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_54",
         "eurostat:nuts_2021_id":"54",
-        "hasc:id":"LT.SH.KM"
+        "hasc:id":"LT.SH.KM",
+        "iso:code":"LT-19",
+        "qs:local_id":"654"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"73131cee09b162cc4068d2f9bc3f25c3",
     "wof:hierarchy":[
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":102073673,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Kelme",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/675/102073675.geojson
+++ b/data/102/073/675/102073675.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":16038,
     "eurostat:population_year":2020,
     "geom:area":0.011379,
-    "geom:area_square_m":78745171.579553,
+    "geom:area_square_m":78745069.153836,
     "geom:bbox":"21.04854,55.855274,21.138926,56.077278",
     "geom:latitude":55.969368,
     "geom:longitude":21.090729,
@@ -271,10 +271,16 @@
         "eurostat:nuts_2021_id":"25",
         "gp:id":2346071,
         "hasc:id":"LT.KP.PG",
+        "iso:code":"LT-31",
+        "qs:local_id":"325",
         "wd:id":"Q2047414"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"4ff5d1348a68c6ab43aae9355e52c508",
+    "wof:geomhash":"6566ea7597b363910389ee22cb7a9e80",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -284,7 +290,7 @@
         }
     ],
     "wof:id":102073675,
-    "wof:lastmodified":1690938604,
+    "wof:lastmodified":1695886743,
     "wof:name":"Palanga",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/677/102073677.geojson
+++ b/data/102/073/677/102073677.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_27",
         "eurostat:nuts_2021_id":"27",
-        "hasc:id":"LT.PA.PV"
+        "hasc:id":"LT.PA.PV",
+        "iso:code":"LT-32",
+        "qs:local_id":"527"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"4e6ff5653e2ce56bcf5450dd32b7f9fc",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073677,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Paneve\u017eys",
     "wof:parent_id":85685779,
     "wof:placetype":"county",

--- a/data/102/073/679/102073679.geojson
+++ b/data/102/073/679/102073679.geojson
@@ -190,8 +190,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_71",
         "eurostat:nuts_2021_id":"71",
-        "hasc:id":"LT.SH.RD"
+        "hasc:id":"LT.SH.RD",
+        "iso:code":"LT-37",
+        "qs:local_id":"671"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"274b78e6cb982dfd7dbc4f996e2d7e41",
     "wof:hierarchy":[
@@ -203,7 +209,7 @@
         }
     ],
     "wof:id":102073679,
-    "wof:lastmodified":1684353993,
+    "wof:lastmodified":1695886743,
     "wof:name":"Radvili\u0161kis",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/681/102073681.geojson
+++ b/data/102/073/681/102073681.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":37425,
     "eurostat:population_year":2020,
     "geom:area":0.142235,
-    "geom:area_square_m":984053492.455108,
+    "geom:area_square_m":984053098.995284,
     "geom:bbox":"21.100703,55.785644,21.700139,56.152087",
     "geom:latitude":55.977727,
     "geom:longitude":21.37834,
@@ -167,10 +167,16 @@
         "eg:gisco_id":"LT_56",
         "eurostat:nuts_2021_id":"56",
         "hasc:id":"LT.KP.KG",
+        "iso:code":"LT-22",
+        "qs:local_id":"356",
         "wd:id":"Q156560"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"3083a9befd846458b6b397e464e975be",
+    "wof:geomhash":"ee21cd57728b994b296e6c17d2c9ec4c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +186,7 @@
         }
     ],
     "wof:id":102073681,
-    "wof:lastmodified":1690938605,
+    "wof:lastmodified":1695886744,
     "wof:name":"Kretinga",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/683/102073683.geojson
+++ b/data/102/073/683/102073683.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":101511,
     "eurostat:population_year":2020,
     "geom:area":0.011644,
-    "geom:area_square_m":80708132.71451,
+    "geom:area_square_m":80708169.887744,
     "geom:bbox":"23.228003,55.840827,23.429041,55.971262",
     "geom:latitude":55.905014,
     "geom:longitude":23.324852,
@@ -395,10 +395,16 @@
         "eg:gisco_id":"LT_29",
         "eurostat:nuts_2021_id":"29",
         "hasc:id":"LT.SH.SL",
+        "iso:code":"LT-43",
+        "qs:local_id":"629",
         "wd:id":"Q134712"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"a825578e97b57128b82d5fda7c3620b5",
+    "wof:geomhash":"9f0ff03bc32a3633aac226989d36708a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -408,7 +414,7 @@
         }
     ],
     "wof:id":102073683,
-    "wof:lastmodified":1690938612,
+    "wof:lastmodified":1695886744,
     "wof:name":"\u0160iauliai",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/685/102073685.geojson
+++ b/data/102/073/685/102073685.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":14430,
     "eurostat:population_year":2020,
     "geom:area":0.204585,
-    "geom:area_square_m":1436876811.173402,
+    "geom:area_square_m":1436876821.10525,
     "geom:bbox":"25.857146,55.209159,26.835949,55.611647",
     "geom:latitude":55.389415,
     "geom:longitude":26.313868,
@@ -221,10 +221,16 @@
         "eg:gisco_id":"LT_45",
         "eurostat:nuts_2021_id":"45",
         "hasc:id":"LT.UN.IG",
+        "iso:code":"LT-09",
+        "qs:local_id":"945",
         "wd:id":"Q2069330"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"ded326453d0e64ae6fe86204a33d0c64",
+    "wof:geomhash":"589db9465e0ff7e0e725baea1bddb4aa",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +240,7 @@
         }
     ],
     "wof:id":102073685,
-    "wof:lastmodified":1690938611,
+    "wof:lastmodified":1695886744,
     "wof:name":"Ignalina",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/687/102073687.geojson
+++ b/data/102/073/687/102073687.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":23038,
     "eurostat:population_year":2020,
     "geom:area":0.251157,
-    "geom:area_square_m":1756690076.432839,
+    "geom:area_square_m":1756689935.877028,
     "geom:bbox":"24.653043,55.305821,25.519213,55.764396",
     "geom:latitude":55.552335,
     "geom:longitude":25.074306,
@@ -198,10 +198,16 @@
         "eg:gisco_id":"LT_34",
         "eurostat:nuts_2021_id":"34",
         "hasc:id":"LT.UN.AN",
+        "iso:code":"LT-04",
+        "qs:local_id":"934",
         "wd:id":"Q2089772"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"119203cf80dd89022ce3be95720b0d16",
+    "wof:geomhash":"58c93b76f97f93500bf0a97eed86aa1b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -211,7 +217,7 @@
         }
     ],
     "wof:id":102073687,
-    "wof:lastmodified":1690938606,
+    "wof:lastmodified":1695886744,
     "wof:name":"Anyk\u0161ciai",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/691/102073691.geojson
+++ b/data/102/073/691/102073691.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":18243,
     "eurostat:population_year":2020,
     "geom:area":0.008268,
-    "geom:area_square_m":57780644.871395,
+    "geom:area_square_m":57780517.217425,
     "geom:bbox":"26.386784,55.550468,26.626777,55.620435",
     "geom:latitude":55.586301,
     "geom:longitude":26.490656,
@@ -247,10 +247,16 @@
         "eg:gisco_id":"LT_30",
         "eurostat:nuts_2021_id":"30",
         "hasc:id":"LT.UN.VG",
+        "iso:code":"LT-59",
+        "qs:local_id":"930",
         "wd:id":"Q203892"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"f4e83523a1d9716e30a0953bc80d26ad",
+    "wof:geomhash":"dbf298dc46b5f171b563543757116230",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -260,7 +266,7 @@
         }
     ],
     "wof:id":102073691,
-    "wof:lastmodified":1690938614,
+    "wof:lastmodified":1695886744,
     "wof:name":"Visaginas",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/693/102073693.geojson
+++ b/data/102/073/693/102073693.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":37184,
     "eurostat:population_year":2020,
     "geom:area":0.174922,
-    "geom:area_square_m":1224738368.351652,
+    "geom:area_square_m":1224739005.70742,
     "geom:bbox":"25.357996,55.277902,26.063887,55.743263",
     "geom:latitude":55.511638,
     "geom:longitude":25.692452,
@@ -155,10 +155,16 @@
         "eg:gisco_id":"LT_82",
         "eurostat:nuts_2021_id":"82",
         "hasc:id":"LT.UN.UT",
+        "iso:code":"LT-54",
+        "qs:local_id":"982",
         "wd:id":"Q2089798"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"4bd6de21e4f025a760dbda13640e405a",
+    "wof:geomhash":"61244fe4637b7c52f84dc2e5c372ebf2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -168,7 +174,7 @@
         }
     ],
     "wof:id":102073693,
-    "wof:lastmodified":1690938608,
+    "wof:lastmodified":1695886744,
     "wof:name":"Utena",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/695/102073695.geojson
+++ b/data/102/073/695/102073695.geojson
@@ -92,8 +92,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_68",
         "eurostat:nuts_2021_id":"68",
-        "hasc:id":"LT.TL.PU"
+        "hasc:id":"LT.TL.PU",
+        "iso:code":"LT-35",
+        "qs:local_id":"868"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"81374e617ffaaa3360f42befb8fb2dfe",
     "wof:hierarchy":[
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":102073695,
-    "wof:lastmodified":1684353994,
+    "wof:lastmodified":1695886744,
     "wof:name":"Plunge",
     "wof:parent_id":85685741,
     "wof:placetype":"county",

--- a/data/102/073/697/102073697.geojson
+++ b/data/102/073/697/102073697.geojson
@@ -43,7 +43,10 @@
         85685783
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "qs:local_id":"999"
+    },
+    "wof:concordances_official":"qs:local_id",
     "wof:country":"LT",
     "wof:geomhash":"4bd540848500e4a91103017e7e16ca28",
     "wof:hierarchy":[
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":102073697,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886953,
     "wof:name":"",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/699/102073699.geojson
+++ b/data/102/073/699/102073699.geojson
@@ -218,8 +218,14 @@
         "eg:gisco_id":"LT_78",
         "eurostat:nuts_2021_id":"78",
         "gp:id":2346090,
-        "hasc:id":"LT.TL.TE"
+        "hasc:id":"LT.TL.TE",
+        "iso:code":"LT-51",
+        "qs:local_id":"878"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"645d8bf603a96bb843ff7d71e491d7e7",
     "wof:hierarchy":[
@@ -231,7 +237,7 @@
         }
     ],
     "wof:id":102073699,
-    "wof:lastmodified":1684353994,
+    "wof:lastmodified":1695886744,
     "wof:name":"Tel\u0161iai",
     "wof:parent_id":85685741,
     "wof:placetype":"county",

--- a/data/102/073/701/102073701.geojson
+++ b/data/102/073/701/102073701.geojson
@@ -79,8 +79,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_66",
         "eurostat:nuts_2021_id":"66",
-        "hasc:id":"LT.PA.PN"
+        "hasc:id":"LT.PA.PN",
+        "iso:code":"LT-33",
+        "qs:local_id":"566"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"f21fa36f59410194f9b00fdbd5bb19e9",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":102073701,
-    "wof:lastmodified":1684353994,
+    "wof:lastmodified":1695886744,
     "wof:name":"Paneve\u017eys",
     "wof:parent_id":85685779,
     "wof:placetype":"county",

--- a/data/102/073/703/102073703.geojson
+++ b/data/102/073/703/102073703.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":41447,
     "eurostat:population_year":2020,
     "geom:area":0.260052,
-    "geom:area_square_m":1798817913.075673,
+    "geom:area_square_m":1798817786.196963,
     "geom:bbox":"22.584328,55.731432,23.590205,56.214536",
     "geom:latitude":55.98534,
     "geom:longitude":23.116196,
@@ -395,10 +395,16 @@
         "eg:gisco_id":"LT_91",
         "eurostat:nuts_2021_id":"91",
         "hasc:id":"LT.SH.SA",
+        "iso:code":"LT-44",
+        "qs:local_id":"691",
         "wd:id":"Q134712"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"8e12302ad43e48e17d4320f5d8023603",
+    "wof:geomhash":"5a5fae91bd09d57947804e46365d1c93",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -408,7 +414,7 @@
         }
     ],
     "wof:id":102073703,
-    "wof:lastmodified":1690938611,
+    "wof:lastmodified":1695886744,
     "wof:name":"\u0160iauliai",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/705/102073705.geojson
+++ b/data/102/073/705/102073705.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":16356,
     "eurostat:population_year":2020,
     "geom:area":0.154893,
-    "geom:area_square_m":1075335504.264608,
+    "geom:area_square_m":1075335026.780237,
     "geom:bbox":"24.678118,55.682312,25.365842,56.051331",
     "geom:latitude":55.84396,
     "geom:longitude":25.028053,
@@ -184,10 +184,16 @@
         "eg:gisco_id":"LT_57",
         "eurostat:nuts_2021_id":"57",
         "hasc:id":"LT.PA.KK",
+        "iso:code":"LT-23",
+        "qs:local_id":"557",
         "wd:id":"Q2089791"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"716e99901a937ccf25067febab2c6c13",
+    "wof:geomhash":"b5eea68f26bb5f2b45da711e06006431",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -197,7 +203,7 @@
         }
     ],
     "wof:id":102073705,
-    "wof:lastmodified":1690938610,
+    "wof:lastmodified":1695886744,
     "wof:name":"Kupi\u0161kis",
     "wof:parent_id":85685779,
     "wof:placetype":"county",

--- a/data/102/073/709/102073709.geojson
+++ b/data/102/073/709/102073709.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":14915,
     "eurostat:population_year":2020,
     "geom:area":0.185619,
-    "geom:area_square_m":1293231249.080878,
+    "geom:area_square_m":1293231535.679557,
     "geom:bbox":"25.680158,55.515937,26.638052,55.944107",
     "geom:latitude":55.705506,
     "geom:longitude":26.094168,
@@ -164,10 +164,16 @@
         "eg:gisco_id":"LT_43",
         "eurostat:nuts_2021_id":"43",
         "hasc:id":"LT.UN.ZA",
+        "iso:code":"LT-60",
+        "qs:local_id":"943",
         "wd:id":"Q664415"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"54f1eb19ef6cec867ad7ec70d2a0ed0e",
+    "wof:geomhash":"6310586410a2005c114bcdec4174ea49",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +183,7 @@
         }
     ],
     "wof:id":102073709,
-    "wof:lastmodified":1690938604,
+    "wof:lastmodified":1695886744,
     "wof:name":"Zarasai",
     "wof:parent_id":85685783,
     "wof:placetype":"county",

--- a/data/102/073/711/102073711.geojson
+++ b/data/102/073/711/102073711.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":16084,
     "eurostat:population_year":2020,
     "geom:area":0.131959,
-    "geom:area_square_m":907341860.47961,
+    "geom:area_square_m":907341878.344238,
     "geom:bbox":"21.225776,56.069899,22.017934,56.38535",
     "geom:latitude":56.215351,
     "geom:longitude":21.68418,
@@ -161,10 +161,16 @@
         "eg:gisco_id":"LT_75",
         "eurostat:nuts_2021_id":"75",
         "hasc:id":"LT.KP.SD",
+        "iso:code":"LT-48",
+        "qs:local_id":"375",
         "wd:id":"Q219115"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"da7ef110cbbbe0fae101f8a7255c3913",
+    "wof:geomhash":"63a010393f094a87c84aa8e3738ce6b5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -174,7 +180,7 @@
         }
     ],
     "wof:id":102073711,
-    "wof:lastmodified":1690938616,
+    "wof:lastmodified":1695886744,
     "wof:name":"Skuodas",
     "wof:parent_id":85685747,
     "wof:placetype":"county",

--- a/data/102/073/713/102073713.geojson
+++ b/data/102/073/713/102073713.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":51056,
     "eurostat:population_year":2020,
     "geom:area":0.176738,
-    "geom:area_square_m":1213599951.134649,
+    "geom:area_square_m":1213600056.977259,
     "geom:bbox":"21.932097,56.08789,22.646966,56.432488",
     "geom:latitude":56.26703,
     "geom:longitude":22.283425,
@@ -180,10 +180,16 @@
         "eg:gisco_id":"LT_61",
         "eurostat:nuts_2021_id":"61",
         "hasc:id":"LT.TL.MZ",
+        "iso:code":"LT-26",
+        "qs:local_id":"861",
         "wd:id":"Q313132"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"2015c5878c1b6f8cc3507d437dede461",
+    "wof:geomhash":"d48d87e21ae51ff4a85589110c65d09d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -193,7 +199,7 @@
         }
     ],
     "wof:id":102073713,
-    "wof:lastmodified":1690938609,
+    "wof:lastmodified":1695886744,
     "wof:name":"Ma\u017eeikiai",
     "wof:parent_id":85685741,
     "wof:placetype":"county",

--- a/data/102/073/715/102073715.geojson
+++ b/data/102/073/715/102073715.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":18772,
     "eurostat:population_year":2020,
     "geom:area":0.122281,
-    "geom:area_square_m":840224016.697892,
+    "geom:area_square_m":840223582.32075,
     "geom:bbox":"22.53031,56.069327,23.128107,56.414848",
     "geom:latitude":56.241625,
     "geom:longitude":22.822581,
@@ -177,10 +177,16 @@
         "eg:gisco_id":"LT_32",
         "eurostat:nuts_2021_id":"32",
         "hasc:id":"LT.SH.AK",
+        "iso:code":"LT-01",
+        "qs:local_id":"632",
         "wd:id":"Q1023041"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"e6a0d25882e360da889be5d532aeb561",
+    "wof:geomhash":"835d013e77683075d378c6ebb31e18ad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -190,7 +196,7 @@
         }
     ],
     "wof:id":102073715,
-    "wof:lastmodified":1690938609,
+    "wof:lastmodified":1695886745,
     "wof:name":"Akmene",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/717/102073717.geojson
+++ b/data/102/073/717/102073717.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":18607,
     "eurostat:population_year":2020,
     "geom:area":0.189509,
-    "geom:area_square_m":1308578220.333824,
+    "geom:area_square_m":1308578195.961571,
     "geom:bbox":"23.528947,55.815924,24.182598,56.330436",
     "geom:latitude":56.052515,
     "geom:longitude":23.874743,
@@ -167,10 +167,16 @@
         "eg:gisco_id":"LT_65",
         "eurostat:nuts_2021_id":"65",
         "hasc:id":"LT.SH.PK",
+        "iso:code":"LT-30",
+        "qs:local_id":"665",
         "wd:id":"Q1657116"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"6db00e438a205844ca24917cd6e604c9",
+    "wof:geomhash":"9c76b087a7de4dc32046660cc4d82b11",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +186,7 @@
         }
     ],
     "wof:id":102073717,
-    "wof:lastmodified":1690938615,
+    "wof:lastmodified":1695886745,
     "wof:name":"Pakruojis",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/719/102073719.geojson
+++ b/data/102/073/719/102073719.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":22829,
     "eurostat:population_year":2020,
     "geom:area":0.185979,
-    "geom:area_square_m":1283958199.64804,
+    "geom:area_square_m":1283957987.229786,
     "geom:bbox":"24.013254,55.839861,24.68224,56.300617",
     "geom:latitude":56.060093,
     "geom:longitude":24.338781,
@@ -167,10 +167,16 @@
         "eg:gisco_id":"LT_67",
         "eurostat:nuts_2021_id":"67",
         "hasc:id":"LT.PA.PS",
+        "iso:code":"LT-34",
+        "qs:local_id":"567",
         "wd:id":"Q1461920"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"338c837d49476bd94efe556f6b565bd2",
+    "wof:geomhash":"c109ac5457bb9526f37f35cfdd7cf379",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +186,7 @@
         }
     ],
     "wof:id":102073719,
-    "wof:lastmodified":1690938615,
+    "wof:lastmodified":1695886745,
     "wof:name":"Pasvalys",
     "wof:parent_id":85685779,
     "wof:placetype":"county",

--- a/data/102/073/721/102073721.geojson
+++ b/data/102/073/721/102073721.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":28072,
     "eurostat:population_year":2020,
     "geom:area":0.259844,
-    "geom:area_square_m":1798798086.592066,
+    "geom:area_square_m":1798798183.549601,
     "geom:bbox":"25.063441,55.714929,26.046084,56.192005",
     "geom:latitude":55.954836,
     "geom:longitude":25.537505,
@@ -183,10 +183,16 @@
         "eg:gisco_id":"LT_73",
         "eurostat:nuts_2021_id":"73",
         "hasc:id":"LT.PA.RK",
+        "iso:code":"LT-40",
+        "qs:local_id":"573",
         "wd:id":"Q766969"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"0ae87d94ee8a172a7ceca0572f4ef485",
+    "wof:geomhash":"e231b6bbcacae18e8a3c6aa6e79f3b28",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -196,7 +202,7 @@
         }
     ],
     "wof:id":102073721,
-    "wof:lastmodified":1690938615,
+    "wof:lastmodified":1695886745,
     "wof:name":"Roki\u0161kis",
     "wof:parent_id":85685779,
     "wof:placetype":"county",

--- a/data/102/073/723/102073723.geojson
+++ b/data/102/073/723/102073723.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":20730,
     "eurostat:population_year":2020,
     "geom:area":0.166927,
-    "geom:area_square_m":1146828415.413551,
+    "geom:area_square_m":1146828410.029232,
     "geom:bbox":"23.072803,56.061718,23.961327,56.383056",
     "geom:latitude":56.247172,
     "geom:longitude":23.502662,
@@ -178,10 +178,16 @@
         "eg:gisco_id":"LT_47",
         "eurostat:nuts_2021_id":"47",
         "hasc:id":"LT.SH.JS",
+        "iso:code":"LT-11",
+        "qs:local_id":"647",
         "wd:id":"Q610133"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"37b0dd9e5bbe2cc2a5d68021d1840ead",
+    "wof:geomhash":"e7a3f0941b5c2692fbd3d5baea2e2332",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -191,7 +197,7 @@
         }
     ],
     "wof:id":102073723,
-    "wof:lastmodified":1690938609,
+    "wof:lastmodified":1695886745,
     "wof:name":"Joni\u0161kis",
     "wof:parent_id":85685755,
     "wof:placetype":"county",

--- a/data/102/073/727/102073727.geojson
+++ b/data/102/073/727/102073727.geojson
@@ -190,8 +190,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_36",
         "eurostat:nuts_2021_id":"36",
-        "hasc:id":"LT.PA.BZ"
+        "hasc:id":"LT.PA.BZ",
+        "iso:code":"LT-06",
+        "qs:local_id":"536"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"7d767bbec7e7cd964dc88b99899fa3c7",
     "wof:hierarchy":[
@@ -203,7 +209,7 @@
         }
     ],
     "wof:id":102073727,
-    "wof:lastmodified":1684353994,
+    "wof:lastmodified":1695886745,
     "wof:name":"Bir\u017eai",
     "wof:parent_id":85685779,
     "wof:placetype":"county",

--- a/data/117/561/292/1/1175612921.geojson
+++ b/data/117/561/292/1/1175612921.geojson
@@ -266,8 +266,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LT_11",
         "eurostat:nuts_2021_id":"11",
-        "hasc:id":"LT.AS.AT"
+        "hasc:id":"LT.AS.AT",
+        "iso:code":"LT-03",
+        "qs:local_id":"111"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
     "wof:geomhash":"8797ee707279e4db2935a50084f79789",
     "wof:hierarchy":[
@@ -279,7 +285,7 @@
         }
     ],
     "wof:id":1175612921,
-    "wof:lastmodified":1684353994,
+    "wof:lastmodified":1695886745,
     "wof:name":"Alytus",
     "wof:parent_id":85685765,
     "wof:placetype":"county",

--- a/data/856/332/69/85633269.geojson
+++ b/data/856/332/69/85633269.geojson
@@ -1369,6 +1369,7 @@
         "hasc:id":"LT",
         "icao:code":"LY",
         "ioc:id":"LTU",
+        "iso:code":"LT",
         "itu:id":"LTU",
         "m49:code":"440",
         "marc:id":"li",
@@ -1382,6 +1383,7 @@
         "wk:page":"Lithuania",
         "wmo:id":"LT"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LT",
     "wof:country_alpha3":"LTU",
     "wof:geom_alt":[
@@ -1403,7 +1405,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1694492257,
+    "wof:lastmodified":1695881369,
     "wof:name":"Lithuania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/857/41/85685741.geojson
+++ b/data/856/857/41/85685741.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.626082,
-    "geom:area_square_m":4328871305.887101,
+    "geom:area_square_m":4328871702.569123,
     "geom:bbox":"21.512083,55.597018,22.738152,56.432488",
     "geom:latitude":56.001482,
     "geom:longitude":22.164776,
@@ -364,12 +364,18 @@
         "gn:id":864483,
         "gp:id":55848080,
         "hasc:id":"LT.TL",
+        "iso:code":"LT-TE",
         "iso:id":"LT-TE",
+        "qs:local_id":"08",
         "unlc:id":"LT-51",
         "wd:id":"Q188963"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"98d9d18fb295e169ea315ec7a3c44ad2",
+    "wof:geomhash":"fffb8817b44e57fb95954c77fe3353f7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -384,7 +390,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938624,
+    "wof:lastmodified":1695885310,
     "wof:name":"Tel\u0161iai",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/47/85685747.geojson
+++ b/data/856/857/47/85685747.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.745156,
-    "geom:area_square_m":5188578127.109792,
+    "geom:area_square_m":5188577508.152988,
     "geom:bbox":"20.954407,55.179573,22.024847,56.38535",
     "geom:latitude":55.727666,
     "geom:longitude":21.479956,
@@ -334,12 +334,18 @@
         "gn:id":864478,
         "gp:id":55848085,
         "hasc:id":"LT.KP",
+        "iso:code":"LT-KL",
         "iso:id":"LT-KL",
+        "qs:local_id":"03",
         "unlc:id":"LT-21",
         "wd:id":"Q475207"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"2346f0c7b72f6d08dd690db715237e25",
+    "wof:geomhash":"2e5db41f77ca7b4c0b2845545beef08e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -354,7 +360,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938625,
+    "wof:lastmodified":1695885310,
     "wof:name":"Klaipeda",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/53/85685753.geojson
+++ b/data/856/857/53/85685753.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"3",
     "geom:area":0.623155,
-    "geom:area_square_m":4452126745.915047,
+    "geom:area_square_m":4452126606.376546,
     "geom:bbox":"22.588819,54.253323,23.79371,55.104864",
     "geom:latitude":54.704442,
     "geom:longitude":23.171032,
@@ -361,12 +361,18 @@
         "gn:id":864479,
         "gp:id":55848078,
         "hasc:id":"LT.MA",
+        "iso:code":"LT-MR",
         "iso:id":"LT-MR",
+        "qs:local_id":"04",
         "unlc:id":"LT-25",
         "wd:id":"Q853948"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"f66b4314bbf030ce23af7dec2b198778",
+    "wof:geomhash":"8b67e4f5642d37ee5bb836abf3616dd8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -381,7 +387,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938623,
+    "wof:lastmodified":1695885311,
     "wof:name":"Marijampole",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/55/85685755.geojson
+++ b/data/856/857/55/85685755.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":1.227318,
-    "geom:area_square_m":8499696517.158152,
+    "geom:area_square_m":8499696488.340685,
     "geom:bbox":"22.465483,55.463028,24.182598,56.414848",
     "geom:latitude":55.938745,
     "geom:longitude":23.307976,
@@ -373,12 +373,18 @@
         "gn:id":864481,
         "gp:id":55848079,
         "hasc:id":"LT.SH",
+        "iso:code":"LT-SA",
         "iso:id":"LT-SA",
+        "qs:local_id":"06",
         "unlc:id":"LT-44",
         "wd:id":"Q186410"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"4bc5cb0e9f48d24129f0789563f58500",
+    "wof:geomhash":"a7e3dd120f975026c4a0e255f24c84ea",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -393,7 +399,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938623,
+    "wof:lastmodified":1695885311,
     "wof:name":"\u0160iauliai",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/59/85685759.geojson
+++ b/data/856/857/59/85685759.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"1",
     "geom:area":1.360371,
-    "geom:area_square_m":9690688268.769579,
+    "geom:area_square_m":9690687539.122475,
     "geom:bbox":"24.386669,54.127403,26.759367,55.517687",
     "geom:latitude":54.822808,
     "geom:longitude":25.234422,
@@ -368,12 +368,18 @@
         "gn:id":864485,
         "gp:id":55848083,
         "hasc:id":"LT.VI",
+        "iso:code":"LT-VL",
         "iso:id":"LT-VL",
+        "qs:local_id":"10",
         "unlc:id":"LT-58",
         "wd:id":"Q188061"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"39c420d24741da1f8353b70b5100e3c0",
+    "wof:geomhash":"7140f41a0f74137388be05d1d1458907",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -388,7 +394,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938621,
+    "wof:lastmodified":1695885311,
     "wof:name":"Vilnius",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/65/85685765.geojson
+++ b/data/856/857/65/85685765.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.747375,
-    "geom:area_square_m":5403022091.352426,
+    "geom:area_square_m":5403023021.014661,
     "geom:bbox":"23.312414,53.897053,25.02479,54.56342",
     "geom:latitude":54.22147,
     "geom:longitude":24.125309,
@@ -374,12 +374,18 @@
         "gn:id":864389,
         "gp:id":55848082,
         "hasc:id":"LT.AS",
+        "iso:code":"LT-AL",
         "iso:id":"LT-AL",
+        "qs:local_id":"01",
         "unlc:id":"LT-03",
         "wd:id":"Q669470"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"9e35219d628fcbbdf0a62e9d616d92cf",
+    "wof:geomhash":"edb731cc7a425d4168bc24eab380f676",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -394,7 +400,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938622,
+    "wof:lastmodified":1695885311,
     "wof:name":"Alytus",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/67/85685767.geojson
+++ b/data/856/857/67/85685767.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"3",
     "geom:area":0.623536,
-    "geom:area_square_m":4389132688.55293,
+    "geom:area_square_m":4389133079.624337,
     "geom:bbox":"21.649932,55.02412,23.504275,55.688293",
     "geom:latitude":55.300667,
     "geom:longitude":22.448051,
@@ -364,12 +364,18 @@
         "gn:id":864482,
         "gp:id":55848087,
         "hasc:id":"LT.TG",
+        "iso:code":"LT-TA",
         "iso:id":"LT-TA",
+        "qs:local_id":"07",
         "unlc:id":"LT-50",
         "wd:id":"Q188960"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"8a2f164e52f02d133ebc82680a57d162",
+    "wof:geomhash":"5a7f7104bf607f6bc41a1af4967c9559",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -384,7 +390,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938622,
+    "wof:lastmodified":1695885311,
     "wof:name":"Taurage",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/73/85685773.geojson
+++ b/data/856/857/73/85685773.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":1.137647,
-    "geom:area_square_m":8053161045.345361,
+    "geom:area_square_m":8053161083.573423,
     "geom:bbox":"22.67004,54.454694,24.811578,55.576743",
     "geom:latitude":55.076397,
     "geom:longitude":23.883886,
@@ -371,12 +371,18 @@
         "gn:id":864477,
         "gp:id":55848084,
         "hasc:id":"LT.KS",
+        "iso:code":"LT-KU",
         "iso:id":"LT-KU",
+        "qs:local_id":"02",
         "unlc:id":"LT-16",
         "wd:id":"Q853861"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"ae64defaae8b8ea119c78b3469fc39ce",
+    "wof:geomhash":"be71974bd76f59c7aa12eece0eeaa107",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -391,7 +397,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938622,
+    "wof:lastmodified":1695885311,
     "wof:name":"Kaunas",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/79/85685779.geojson
+++ b/data/856/857/79/85685779.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":1.132562,
-    "geom:area_square_m":7847710869.292499,
+    "geom:area_square_m":7847709966.003186,
     "geom:bbox":"23.879444,55.386662,26.046084,56.450657",
     "geom:latitude":55.917882,
     "geom:longitude":24.802874,
@@ -374,12 +374,18 @@
         "gn:id":864480,
         "gp:id":55848086,
         "hasc:id":"LT.PA",
+        "iso:code":"LT-PN",
         "iso:id":"LT-PN",
+        "qs:local_id":"05",
         "unlc:id":"LT-33",
         "wd:id":"Q188085"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"b01d8b00e6fd4caa56ed2a6ecf6bc1c4",
+    "wof:geomhash":"3d70c261600ae2fc85ef6b5b2c1fe495",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -394,7 +400,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938623,
+    "wof:lastmodified":1695885311,
     "wof:name":"Paneve\u017eys",
     "wof:parent_id":85633269,
     "wof:placetype":"region",

--- a/data/856/857/83/85685783.geojson
+++ b/data/856/857/83/85685783.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":1.022064,
-    "geom:area_square_m":7162051297.046462,
+    "geom:area_square_m":7162052193.302017,
     "geom:bbox":"24.653043,55.030913,26.835949,55.944107",
     "geom:latitude":55.478867,
     "geom:longitude":25.699798,
@@ -364,12 +364,18 @@
         "gn:id":864484,
         "gp:id":55848081,
         "hasc:id":"LT.UN",
+        "iso:code":"LT-UT",
         "iso:id":"LT-UT",
+        "qs:local_id":"09",
         "unlc:id":"LT-54",
         "wd:id":"Q188659"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LT",
-    "wof:geomhash":"b8621a4e08682e77020e68e607128680",
+    "wof:geomhash":"b674dfc3881b25527c1ee66210696f1e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -384,7 +390,7 @@
     "wof:lang_x_spoken":[
         "lit"
     ],
-    "wof:lastmodified":1690938624,
+    "wof:lastmodified":1695885311,
     "wof:name":"Utena",
     "wof:parent_id":85633269,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.